### PR TITLE
sedcli: Changing loglevel from LOG_ERROR to LOG_INFO

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -27,6 +27,29 @@ struct sed_key {
 	uint8_t len;
 };
 
+enum sed_status {
+	SED_SUCCESS,
+	SED_NOT_AUTHORIZED,
+	SED_UNKNOWN_ERROR,
+	SED_SP_BUSY,
+	SED_SP_FAILED,
+	SED_SP_DISABLED,
+	SED_SP_FROZEN,
+	SED_NO_SESSIONS_AVAILABLE,
+	SED_UNIQUENESS_CONFLICT,
+	SED_INSUFFICIENT_SPACE,
+	SED_INSUFFICIENT_ROWS,
+	SED_INVALID_FUNCTION,
+	SED_INVALID_PARAMETER,
+	SED_INVALID_REFERENCE,
+	SED_UNKNOWN_ERROR_1,
+	SED_TPER_MALFUNCTION,
+	SED_TRANSACTION_FAILURE,
+	SED_RESPONSE_OVERFLOW,
+	SED_AUTHORITY_LOCKED_OUT,
+	SED_FAIL = 0x3F, /* Fail status code as defined by Opal is higher value */
+};
+
 /**
  * This function initializes libsed for usage. It opens device node file and
  * stores relevant information in data structure representing libsed context.

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -119,26 +119,32 @@ static struct opal_interface opal_if = {
 
 static struct opal_interface *curr_if = &opal_if;
 
-static const char *const sed_errors[] = {
-	"Success",
-	"Not Authorized",
-	"Unknown Error",
-	"SP Busy",
-	"SP Failed",
-	"SP Disabled",
-	"SP Frozen",
-	"No Sessions Available",
-	"Uniqueness Conflict",
-	"Insufficient Space",
-	"Insufficient Rows",
-	"Invalid Function",
-	"Invalid Parameter",
-	"Invalid Reference",
-	"Unknown Error",
-	"TPER Malfunction",
-	"Transaction Failure",
-	"Response Overflow",
-	"Authority Locked Out",
+struct sed_status_ret {
+	int code;
+	const char *text;
+};
+
+struct sed_status_ret sed_statuses[] = {
+	{ .code = SED_SUCCESS, .text = "Success" },
+	{ .code = SED_NOT_AUTHORIZED, .text = "Not Authorized" },
+	{ .code = SED_UNKNOWN_ERROR, .text = "Unknown Error" },
+	{ .code = SED_SP_BUSY, .text = "SP Busy" },
+	{ .code = SED_SP_FAILED, .text = "SP Failed" },
+	{ .code = SED_SP_DISABLED, .text = "SP Disabled" },
+	{ .code = SED_SP_FROZEN, .text = "SP Frozen" },
+	{ .code = SED_NO_SESSIONS_AVAILABLE, .text = "No Sessions Available" },
+	{ .code = SED_UNIQUENESS_CONFLICT, .text = "Uniqueness Conflict" },
+	{ .code = SED_INSUFFICIENT_SPACE, .text = "Insufficient Space" },
+	{ .code = SED_INSUFFICIENT_ROWS, .text = "Insufficient Rows" },
+	{ .code = SED_INVALID_FUNCTION, .text = "Invalid Function" },
+	{ .code = SED_INVALID_PARAMETER, .text = "Invalid Parameter" },
+	{ .code = SED_INVALID_REFERENCE, .text = "Invalid Reference" },
+	{ .code = SED_UNKNOWN_ERROR_1, .text = "Unknown Error" },
+	{ .code = SED_TPER_MALFUNCTION, .text = "TPER Malfunction" },
+	{ .code = SED_TRANSACTION_FAILURE, .text = "Transaction Failure" },
+	{ .code = SED_RESPONSE_OVERFLOW, .text = "Response Overflow" },
+	{ .code = SED_AUTHORITY_LOCKED_OUT, .text = "Authority Locked Out" },
+	{ .code = SED_FAIL, .text = "Failed" },
 };
 
 int sed_init(struct sed_device **dev, const char *dev_path)
@@ -319,14 +325,9 @@ int sed_list_lr(struct sed_device *dev, const char *key, uint8_t key_len)
 
 const char *sed_error_text(int sed_status)
 {
-	/* Fail status code as defined by Opal is higher value*/
-	if (sed_status == 0x3F) {
-		return "Failed\n";
-	}
-
-	if (sed_status >= ARRAY_SIZE(sed_errors) || sed_status < 0) {
+	if ((sed_status > SED_AUTHORITY_LOCKED_OUT && sed_status != SED_FAIL) || sed_status < 0) {
 		return NULL;
 	}
 
-	return sed_errors[sed_status];
+	return sed_statuses[sed_status].text;
 }

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -329,10 +329,33 @@ static int get_password(struct sed_key *pwd)
 	return 0;
 }
 
+static void print_sed_status(int status)
+{
+	const char *sed_status = NULL;
+
+	if (status < 0) {
+		if (status == -EINVAL) {
+			sedcli_printf(LOG_ERR, "Invalid parameter\n");
+		} else if (status == -ENODEV) {
+			sedcli_printf(LOG_ERR, "Couldn't determine device state\n");
+		} else if (status == -ENOMEM) {
+			sedcli_printf(LOG_ERR, "No memory\n");
+		} else {
+			sedcli_printf(LOG_ERR, "Unknown error\n");
+		}
+	} else {
+		sed_status = sed_error_text(status);
+		if (sed_status == NULL)
+			sedcli_printf(LOG_ERR, "Unknown Error\n");
+		else
+			sedcli_printf((status == SED_SUCCESS) ? LOG_INFO : LOG_ERR,
+					"%s\n", sed_status);
+	}
+}
+
 static int handle_ownership(void)
 {
 	struct sed_device *dev = NULL;
-	const char *sed_status = NULL;
 	int ret;
 
 	sedcli_printf(LOG_INFO, "New SID password: ");
@@ -364,17 +387,7 @@ static int handle_ownership(void)
 
 	ret = sed_takeownership(dev, &opts->pwd);
 
-	sed_status = sed_error_text(ret);
-
-	if (sed_status == NULL && ret != 0) {
-		if (ret == -EINVAL) {
-			sedcli_printf(LOG_ERR, "Invalid parameter\n");
-		} else {
-			sedcli_printf(LOG_ERR, "Unknown error\n");
-		}
-	} else {
-		sedcli_printf(LOG_ERR, "%s\n", sed_status);
-	}
+	print_sed_status(ret);
 
 	sed_deinit(dev);
 
@@ -384,7 +397,6 @@ static int handle_ownership(void)
 static int handle_activatelsp(void)
 {
 	struct sed_device *dev = NULL;
-	const char *sed_status = NULL;
 	int ret;
 
 	sedcli_printf(LOG_INFO, "Enter SID password: ");
@@ -403,19 +415,7 @@ static int handle_activatelsp(void)
 
 	ret = sed_activatelsp(dev, &opts->pwd);
 
-	sed_status = sed_error_text(ret);
-
-	if (sed_status == NULL && ret != 0) {
-		if (ret == -EINVAL) {
-			sedcli_printf(LOG_ERR, "Invalid parameter\n");
-		} else if (ret == -ENODEV) {
-			sedcli_printf(LOG_ERR, "Couldn't determine device state\n");
-		} else {
-			sedcli_printf(LOG_ERR, "Unknown error\n");
-		}
-	} else {
-		sedcli_printf(LOG_ERR, "%s\n", sed_status);
-	}
+	print_sed_status(ret);
 
 	sed_deinit(dev);
 
@@ -425,7 +425,6 @@ static int handle_activatelsp(void)
 static int handle_reverttper(void)
 {
 	struct sed_device *dev = NULL;
-	const char *sed_status = NULL;
 	int ret;
 
 	sedcli_printf(LOG_INFO, "Enter %s password: ", opts->psid ? "PSID" : "SID");
@@ -444,17 +443,7 @@ static int handle_reverttper(void)
 
 	ret = sed_reverttper(dev, &opts->pwd, opts->psid);
 
-	sed_status = sed_error_text(ret);
-
-	if (sed_status == NULL && ret != 0) {
-		if (ret == -EINVAL) {
-			sedcli_printf(LOG_ERR, "Invalid parameter\n");
-		} else {
-			sedcli_printf(LOG_ERR, "Unknown error\n");
-		}
-	} else {
-		sedcli_printf(LOG_ERR, "%s\n", sed_status);
-	}
+	print_sed_status(ret);
 
 	sed_deinit(dev);
 
@@ -464,7 +453,6 @@ static int handle_reverttper(void)
 static int handle_lock_unlock(void)
 {
 	struct sed_device *dev = NULL;
-	const char *sed_status = NULL;
 	int ret;
 
 	sedcli_printf(LOG_INFO, "Enter Admin1 password: ");
@@ -483,19 +471,7 @@ static int handle_lock_unlock(void)
 
 	ret = sed_lock_unlock(dev, &opts->pwd, opts->lock_type);
 
-	sed_status = sed_error_text(ret);
-
-	if (sed_status == NULL && ret != 0) {
-		if (ret == -EINVAL) {
-			sedcli_printf(LOG_ERR, "Invalid parameter\n");
-		} else if (ret == -ENOMEM) {
-			sedcli_printf(LOG_ERR, "No memory\n");
-		} else {
-			sedcli_printf(LOG_ERR, "Unknown error\n");
-		}
-	} else {
-		sedcli_printf(LOG_ERR, "%s\n", sed_status);
-	}
+	print_sed_status(ret);
 
 	sed_deinit(dev);
 
@@ -505,7 +481,6 @@ static int handle_lock_unlock(void)
 static int handle_setup_global_range(void)
 {
 	struct sed_device *dev = NULL;
-	const char *sed_status = NULL;
 	int ret;
 
 	sedcli_printf(LOG_INFO, "Enter Admin1 password: ");
@@ -524,17 +499,7 @@ static int handle_setup_global_range(void)
 
 	ret = sed_setup_global_range(dev, &opts->pwd);
 
-	sed_status = sed_error_text(ret);
-
-	if (sed_status == NULL && ret != 0) {
-		if (ret == -EINVAL) {
-			sedcli_printf(LOG_ERR, "Invalid parameter\n");
-		} else {
-			sedcli_printf(LOG_ERR, "Unknown error\n");
-		}
-	} else {
-		sedcli_printf(LOG_ERR, "%s\n", sed_status);
-	}
+	print_sed_status(ret);
 
 	sed_deinit(dev);
 
@@ -544,7 +509,6 @@ static int handle_setup_global_range(void)
 static int handle_setpw(void)
 {
 	struct sed_device *dev = NULL;
-	const char *sed_status = NULL;
 	int ret;
 
 	sedcli_printf(LOG_INFO, "Old Admin1 password: ");
@@ -584,17 +548,7 @@ static int handle_setpw(void)
 
 	ret = sed_setpw(dev, &opts->old_pwd, &opts->pwd);
 
-	sed_status = sed_error_text(ret);
-
-	if (sed_status == NULL && ret != 0) {
-		if (ret == -EINVAL) {
-			sedcli_printf(LOG_ERR, "Invalid parameter\n");
-		} else {
-			sedcli_printf(LOG_ERR, "Unknown error\n");
-		}
-	} else {
-		sedcli_printf(LOG_ERR, "%s\n", sed_status);
-	}
+	print_sed_status(ret);
 
 	sed_deinit(dev);
 


### PR DESCRIPTION
	to print the sed_err_to_text string

The existing log level LOG_ERROR prints sed_err_to_text string into stderr
By changing the log level to LOG_INFO, we now print the string into stdout

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>