### PR TITLE
sedcli: Resync SEDCLI Locktype with Opal Driver

### DIFF
--- a/doc/sedcli.8
+++ b/doc/sedcli.8
@@ -58,9 +58,15 @@ Activates Locking SP.
 .IP "\fB\-R -d <device> [-i]\fR or \fB\-\-revert --device <device> [--psid]\fR"
 Reverts TPer to Manufactured-Inactivate state using either SID or PSID authority.
 
-.IP "\fB\-L -d <device> -t <locktype>\fR or \fB\-\-lock-unlock --device <device> --locktype {RW|RO|WO|UNLOCK}\fR"
-Changes the lock state for the device. There is a possibility to setup Read lock,
-Write lock and Read-Write lock and unlock the device.
+.IP "\fB\-L -d <device> -t <accesstype>\fR or \fB\-\-lock-unlock --device <device> --accesstype {RO|RW|LK}\fR"
+.IP
+Changes the lock state for the device. Following access modes are available:
+.IP
+1. Read-Only(RO) - user can only read the data from the disk.
+.IP
+2. Read-Write(RW) - user can read/write data from/to the disk.
+.IP
+3. Locked(LK) - data is locked, user can NOT read/write data from/to the disk.
 
 .IP "\fB\-P -d <device>\fR or \fB\-\-set-password --device <device>\fR"
 Updates password for Admin1 authority in Locking SP.

--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -13,11 +13,10 @@
 
 #define SED_MAX_KEY_LEN (256)
 
-enum SED_LOCK_TYPE {
-	SED_NO_LOCK = 0x00,
-	SED_READ_LOCK = 0x01,
-	SED_WRITE_LOCK = 0x02,
-	SED_READ_WRITE_LOCK = (SED_READ_LOCK | SED_WRITE_LOCK),
+enum SED_ACCESS_TYPE {
+	SED_RO_ACCESS = 1 << 0,
+	SED_RW_ACCESS = 1 << 1,
+	SED_NO_ACCESS = 1 << 2,
 };
 
 struct sed_device;
@@ -86,7 +85,7 @@ int sed_setup_global_range(struct sed_device *dev, const struct sed_key *key);
 /**
  *
  */
-int sed_lock_unlock(struct sed_device *dev, const struct sed_key *key, enum SED_LOCK_TYPE lock_type);
+int sed_lock_unlock(struct sed_device *dev, const struct sed_key *key, enum SED_ACCESS_TYPE lock_type);
 
 /**
  *

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -322,7 +322,7 @@ int opal_activate_lsp_pt(struct sed_device *dev, const struct sed_key *key,
 		char *lr_str, bool sum);
 
 int opal_add_usr_to_lr_pt(struct sed_device *dev, const char *key, uint8_t key_len,
-		const char *usr, enum SED_LOCK_TYPE lock_type, uint8_t lr);
+		const char *usr, enum SED_ACCESS_TYPE lock_type, uint8_t lr);
 
 int opal_activate_usr_pt(struct sed_device *dev, const char *key, uint8_t key_len,
 		const char *user);
@@ -334,7 +334,7 @@ int opal_setuplr_pt(struct sed_device *dev, const char *key, uint8_t key_len,
 		size_t range_length, bool sum, bool RLE, bool WLE);
 
 int opal_lock_unlock_pt(struct sed_device *dev, const struct sed_key *key,
-		enum SED_LOCK_TYPE lock_type);
+		enum SED_ACCESS_TYPE lock_type);
 
 int opal_set_pwd_pt(struct sed_device *dev, const struct sed_key *old_key,
 		const struct sed_key *new_key);

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -24,13 +24,13 @@ typedef int (*activate_lsp)(struct sed_device *, const struct sed_key *,
 typedef int (*revertsp)(struct sed_device *, const struct sed_key *, bool);
 typedef int (*setup_global_range)(struct sed_device *, const struct sed_key *);
 typedef int (*add_usr_to_lr)(struct sed_device *, const char *, uint8_t,
-			const char *, enum SED_LOCK_TYPE, uint8_t);
+			const char *, enum SED_ACCESS_TYPE, uint8_t);
 typedef int (*activate_usr)(struct sed_device *, const char *, uint8_t,
 			const char *);
 typedef int (*setuplr)(struct sed_device *, const char *, uint8_t,
 			const char *, uint8_t, size_t, size_t, bool,
 			bool, bool);
-typedef int (*lock_unlock)(struct sed_device *, const struct sed_key *, enum SED_LOCK_TYPE);
+typedef int (*lock_unlock)(struct sed_device *, const struct sed_key *, enum SED_ACCESS_TYPE);
 typedef int (*set_pwd)(struct sed_device *, const struct sed_key *, const struct sed_key *);
 typedef int (*shadow_mbr)(struct sed_device *, const char *,
 			uint8_t, bool);
@@ -230,13 +230,13 @@ int sed_activatelsp(struct sed_device *dev, const struct sed_key *key)
 }
 
 int sed_lock_unlock(struct sed_device *dev, const struct sed_key *key,
-		enum SED_LOCK_TYPE lock_type)
+		enum SED_ACCESS_TYPE lock_type)
 {
 	return curr_if->lock_unlock_fn(dev, key, lock_type);
 }
 
 int sed_addusertolr(struct sed_device *dev, const char *pass, uint8_t key_len,
-		    const char *user, enum SED_LOCK_TYPE lock_type, uint8_t lr)
+		    const char *user, enum SED_ACCESS_TYPE lock_type, uint8_t lr)
 {
 	return curr_if->addusr_to_lr_fn(dev, pass, key_len, user, lock_type, lr);
 }

--- a/src/lib/sed_ioctl.h
+++ b/src/lib/sed_ioctl.h
@@ -14,7 +14,7 @@
 int sedopal_init(struct sed_device *dev, const char *device_path);
 
 int sedopal_lock_unlock(struct sed_device *dev, const struct sed_key *key,
-						enum SED_LOCK_TYPE lock_type);
+						enum SED_ACCESS_TYPE lock_type);
 
 int sedopal_takeownership(struct sed_device *dev, const struct sed_key *key);
 
@@ -27,7 +27,7 @@ int sedopal_setuplr(struct sed_device *dev, const char *password,
 int sedopal_setup_global_range(struct sed_device *dev, const struct sed_key *key);
 
 int sedopal_add_usr_to_lr(struct sed_device *dev, const char *key, uint8_t key_len,
-			const char *user, enum SED_LOCK_TYPE lock_type, uint8_t lr);
+			const char *user, enum SED_ACCESS_TYPE lock_type, uint8_t lr);
 
 int sedopal_shadowmbr(struct sed_device *dev, const char *password,
 		uint8_t key_len,
@@ -48,7 +48,7 @@ int sedopal_secure_erase_lr(struct sed_device *dev, const char *password,
 int sedopal_reverttper(struct sed_device *dev, const struct sed_key *key, bool psid);
 
 int sedopal_save(struct sed_device *dev, const char *password, uint8_t key_len,
-				const char *user, enum SED_LOCK_TYPE lock_type, uint8_t lr, bool sum);
+				const char *user, enum SED_ACCESS_TYPE lock_type, uint8_t lr, bool sum);
 
 void sedopal_deinit(struct sed_device *dev);
 

--- a/src/lib/sed_util.h
+++ b/src/lib/sed_util.h
@@ -10,10 +10,10 @@
 #include <stdint.h>
 #include <libsed.h>
 
-enum sed_lock_state {
-	SED_RO = 0x01,
-	SED_RW = 0x02,
-	SED_LK = 0x04,
+enum SED_ACCESSTYPE {
+	SED_RO = 0x01, /* 1 << 0 */
+	SED_RW = 0x02, /* 1 << 1 */
+	SED_LK = 0x04, /* 1 << 2 */
 };
 
 enum sed_user {

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -63,7 +63,7 @@ static cli_option reverttper_opts[] = {
 
 static cli_option lock_unlock_opts[] = {
 	{'d', "device", "Device node e.g. /dev/nvme0n1", 1, "DEVICE", CLI_OPTION_REQUIRED},
-	{'t', "locktype", "String specifying how to lock/unlock drive. Allowed values: RW/RO/WO/UNLOCK", 1, "FMT", CLI_OPTION_REQUIRED},
+	{'t', "accesstype", "String specifying access type to the data on drive. Allowed values: RO/RW/LK", 1, "FMT", CLI_OPTION_REQUIRED},
 	{0}
 };
 
@@ -181,12 +181,7 @@ struct sedcli_options {
 
 static struct sedcli_options *opts = NULL;
 
-static char *allowed_lock_type[] = {
-	[SED_NO_LOCK] = "UNLOCK",
-	[SED_READ_LOCK] = "WO",
-	[SED_WRITE_LOCK] = "RO",
-	[SED_READ_WRITE_LOCK] = "RW",
-};
+static char *allowed_lock_type[] = {"RO", "RW", "LK"};
 
 static struct termios term;
 
@@ -240,7 +235,7 @@ static int get_lock_type(const char *lock_type)
 
 	for (i = 0; i < ARRAY_SIZE(allowed_lock_type); i++) {
 		if (0 == strcmp(allowed_lock_type[i], lock_type)) {
-			return i;
+			return (1 << i);
 		}
 	}
 
@@ -251,7 +246,7 @@ int lock_unlock_handle_opts(char *opt, char **arg)
 {
 	if (!strcmp(opt, "device")) {
 		strncpy(opts->dev_path, arg[0], PATH_MAX - 1);
-	} else if (!strcmp(opt, "locktype")) {
+	} else if (!strcmp(opt, "accesstype")) {
 		opts->lock_type = get_lock_type(arg[0]);
 		if (opts->lock_type == -1) {
 			sedcli_printf(LOG_ERR, "Incorrect lock type\n");


### PR DESCRIPTION
This patch resyncs sedcli locktype with opal driver.
Also, this patch updates the code wherever required
inaccordance.