### PR TITLE
Initilize sed_device field to prevent sedcli crash on deinit

### DIFF
--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -300,6 +300,9 @@ int opal_init_pt(struct sed_device *dev, const char *device_path)
 	int ret = 0;
 	struct opal_device *opal_dev = NULL;
 
+	dev->fd = 0;
+	dev->priv = NULL;
+
 	ret = open_dev(device_path);
 	if (ret < 0)
 		return -ENODEV;

--- a/src/lib/sed_ioctl.c
+++ b/src/lib/sed_ioctl.c
@@ -28,6 +28,9 @@ int sedopal_init(struct sed_device *dev, const char *device_path)
 {
 	int ret = 0;
 
+	dev->fd = 0;
+	dev->priv = NULL;
+
 	ret = open_dev(device_path);
 	if (ret < 0)
 		return -ENODEV;


### PR DESCRIPTION
This patch initializes sed_device members to prevent crash resulting
from freeing randomly initialized priv pointer in deintialization path.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@intel.com>