### PR TITLE
Detect shared object install directory for distribution

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -100,14 +100,14 @@ distclean: clean
 install:
 	@echo " Installing $(TARGET)"
 	install -m 755 $(TARGET)-dynamic /usr/sbin/$(TARGET)
-	install -m 755 $(LIB).so.1.0.1 /usr/lib64/
-	ln -sf /usr/lib64/$(LIB).so.1.0.1 /usr/lib64/$(LIB).so.1
+	install -m 755 $(LIB).so.1.0.1 $(LIB_DIR)
+	ln -sf $(LIB_DIR)/$(LIB).so.1.0.1 $(LIB_DIR)/$(LIB).so.1
 	install -m 644 ../doc/$(TARGET).8 /usr/share/man/man8/$(TARGET).8
 
 uninstall:
 	@echo "  Removing $(TARGET)"
 	-rm /usr/sbin/$(TARGET)
-	-rm /usr/lib64/$(LIB).so*
+	-rm $(LIB_DIR)/$(LIB).so*
 	-rm /usr/share/man/man8/$(TARGET).8
 
 .PHONY: clean all distclean install uninstall

--- a/src/configure
+++ b/src/configure
@@ -58,6 +58,11 @@ function common_mk() {
 	app_config_mk "CFLAGS+=-include ${CONFIG_H}"
 	app_config_mk "CFLAGS+=-O2 -g -Wall -Werror -Wno-unused-function -Wno-address-of-packed-member -fstack-protector-all -std=gnu99"
 	app_config_mk "LDFLAGS+=-L."
+	if [ -f /etc/lsb-release ] && [ -n "`cat /etc/lsb-release | grep -i ubuntu`" ]; then
+		app_config_mk "LIB_DIR=/lib/x86_64-linux-gnu"
+	else
+		app_config_mk "LIB_DIR=/usr/lib64"
+	fi
 }
 
 function print_help() {


### PR DESCRIPTION
This patch fixes a problem where installation script installed libsed
shared object into directory that wasn't in linker search path causing
sedcli not to run. This patch discovers lib installation directory and
configures build script accordingly.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@intel.com>