### PR TITLE
sedcli: Fix the MAX key length based on spec

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define SED_MAX_KEY_LEN (256)
+#define SED_MAX_KEY_LEN (32)
 
 enum SED_ACCESS_TYPE {
 	SED_RO_ACCESS = 1 << 0,

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -183,7 +183,7 @@ void sed_deinit(struct sed_device *dev)
 int sed_key_init(struct sed_key *auth_key, const char *key, const uint8_t key_len)
 {
 	uint8_t src_len = key_len;
-	uint8_t dest_len = SED_MAX_KEY_LEN - 1;
+	uint8_t dest_len = SED_MAX_KEY_LEN;
 
 	if (src_len == 0) {
 		return -EINVAL;


### PR DESCRIPTION
This patch aims at fixing the maximum allowable key length as per
the opal spec.
Reference: Section 5.3.3.16.2 of
https://trustedcomputinggroup.org/wp-content/uploads/TCG_Storage_Architecture_Core_Spec_v2.01_r1.00.pdf

Also, this patch makes suitable changes in sedcli_main file to be
in-par with this change

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>