### PR TITLE
sed-cli: CLI to perform level0 Discovery and provide device info. 

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -70,7 +70,7 @@ function print_help() {
 	echo "Options:"
 	echo "    --enable-kmip           Doesn't take any effect yet"
 	echo "    --enable-logging        Turns on sedcli debug logging to stdout"
-	echo "    --force-nvme-pt         Force compilation of NVMe PT interface, instead of using kernel Opal driver (if available)"
+	echo "    --force-opal-driver     Force compilation of Linux opal driver interface, instead of using NVMe PT"
 }
 
 function print_summary() {
@@ -82,12 +82,12 @@ function print_summary() {
 # Default settings
 kmip_enabled="no"
 sedcli_logging="no"
-force_nvme_pt="no"
+force_opal_driver="no"
 
 # Process user specified options
 for option do
 	case "$option" in
-	--force-nvme-pt) force_nvme_pt="yes"
+	--force-opal-driver) force_opal_driver="yes"
 	;;
 	--enable-kmip) kmip_enabled="yes"
 	;;
@@ -161,7 +161,7 @@ int main(void)
 }
 EOF
 
-if test_compile "sed interface" && [ "${force_nvme_pt}" == "no" ]; then
+if [ "${force_opal_driver}" == "yes" ] && test_compile "sed interface"; then
 	print_status "SED interface" "opal-driver"
 	app_config_mk "CONFIG_OPAL_DRIVER=y"
 	app_config_h "#define CONFIG_OPAL_DRIVER"
@@ -178,7 +178,7 @@ EOF
 		app_config_h "#define CONFIG_OPAL_DRIVER_PSID_REVERT"
 	fi
 else
-	print_status "SED interface" "NVMe-PT"
+	print_status "SED interface" "NVMe-PT (force-opal-driver=${force_opal_driver})"
 fi
 # ==========================================
 

--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -13,6 +13,8 @@
 
 #define SED_MAX_KEY_LEN (32)
 
+#define ENOTSUPP 524 /* Device is not SED compliant */
+
 enum SED_ACCESS_TYPE {
 	SED_RO_ACCESS = 1 << 0,
 	SED_RW_ACCESS = 1 << 1,

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -333,6 +333,8 @@ int opal_init_pt(struct sed_device *dev, const char *device_path)
 		return -EINVAL;
 	}
 	SEDCLI_DEBUG_PARAM("The device comid is: %u\n", opal_dev->comid);
+	if (!opal_dev->comid)
+		ret = -ENOTSUPP;
 
 	return ret;
 }


### PR DESCRIPTION
This patch aims at providing an cli that helps the user to check
if the device provided by the user is SED-OPAL compliant or not.
This works fine only with NVMe passthru mechanism.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>