### PR TITLE
Use NVMe PT by default for accessing Opal

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -70,7 +70,7 @@ function print_help() {
 	echo "Options:"
 	echo "    --enable-kmip           Doesn't take any effect yet"
 	echo "    --enable-logging        Turns on sedcli debug logging to stdout"
-	echo "    --force-nvme-pt         Force compilation of NVMe PT interface, instead of using kernel Opal driver (if available)"
+	echo "    --force-opal-driver     Force compilation of Linux opal driver interface, instead of using NVMe PT"
 }
 
 function print_summary() {
@@ -82,12 +82,12 @@ function print_summary() {
 # Default settings
 kmip_enabled="no"
 sedcli_logging="no"
-force_nvme_pt="no"
+force_opal_driver="no"
 
 # Process user specified options
 for option do
 	case "$option" in
-	--force-nvme-pt) force_nvme_pt="yes"
+	--force-opal-driver) force_opal_driver="yes"
 	;;
 	--enable-kmip) kmip_enabled="yes"
 	;;
@@ -161,7 +161,7 @@ int main(void)
 }
 EOF
 
-if test_compile "sed interface" && [ "${force_nvme_pt}" == "no" ]; then
+if [ "${force_opal_driver}" == "yes" ] && test_compile "sed interface"; then
 	print_status "SED interface" "opal-driver"
 	app_config_mk "CONFIG_OPAL_DRIVER=y"
 	app_config_h "#define CONFIG_OPAL_DRIVER"
@@ -178,7 +178,7 @@ EOF
 		app_config_h "#define CONFIG_OPAL_DRIVER_PSID_REVERT"
 	fi
 else
-	print_status "SED interface" "NVMe-PT"
+	print_status "SED interface" "NVMe-PT (force-opal-driver=${force_opal_driver})"
 fi
 # ==========================================
 


### PR DESCRIPTION
This patch modifies behaviour of build configuration script to use NVMe
PT interface by default instead of auto detecting available interfaces
(Linux Opal driver or NVMe PT) and using it. By default NVMe PT
interface is compiled in. If one seeks to use Linux Opal interface it is
possible to force build configuration script to try to use it. If
distribution doesn't provide Linux Opal interface and user forces build
configuration script to use it, script will fallback to using NVMe PT
interface.

Change-Id: I9340644ad80907ea333ab72174cdd058b852a144
Signed-off-by: Andrzej Jakowski <andrzej.jakowski@intel.com>