### PR TITLE
sed-cli: CLI to perform level0 Discovery and provide device info.

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -21,6 +21,42 @@ enum SED_ACCESS_TYPE {
 
 struct sed_device;
 
+struct sed_tper_supported_feat {
+	uint8_t sync_supp :1;
+	uint8_t async_supp :1;
+	uint8_t ack_nak_supp :1;
+	uint8_t buff_mgmt_supp :1;
+	uint8_t stream_supp :1;
+	uint8_t reserved1 :1;
+	uint8_t comid_mgmt_supp :1;
+	uint8_t reserved2:1;
+} __attribute__((__packed__));
+
+struct sed_locking_supported_feat {
+	uint8_t locking_supp:1;
+	uint8_t locking_en:1;
+	uint8_t locked:1;
+	uint8_t media_enc:1;
+	uint8_t mbr_en:1;
+	uint8_t mbr_done:1;
+	uint8_t reserved:2;
+} __attribute__((__packed__));
+
+struct sed_opalv200_supported_feat {
+	uint16_t base_comid;
+	uint16_t comid_num;
+	uint8_t reserved1;
+	uint16_t admin_lp_auth_num;
+	uint16_t user_lp_auth_num;
+	uint8_t reserved2[7];
+} __attribute__((__packed__));
+
+struct sed_opal_level0_discovery {
+	struct sed_tper_supported_feat sed_tper;
+	struct sed_locking_supported_feat sed_locking;
+	struct sed_opalv200_supported_feat sed_opalv200;
+};
+
 struct sed_key {
 	uint8_t key[SED_MAX_KEY_LEN];
 	uint8_t len;
@@ -56,6 +92,11 @@ enum sed_status {
  * operation.
  */
 int sed_init(struct sed_device **dev, const char *dev_path);
+
+/**
+ *
+ */
+int sed_level0_discovery(struct sed_opal_level0_discovery *discv);
 
 /**
  *

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -182,38 +182,48 @@ enum opaltoken {
 	OPAL_WHERE = 0x00,
 };
 
+struct tper_supported_feat {
+	uint8_t sync_supp :1;
+	uint8_t async_supp :1;
+	uint8_t ack_nak_supp :1;
+	uint8_t buff_mgmt_supp :1;
+	uint8_t stream_supp :1;
+	uint8_t reserved1 :1;
+	uint8_t comid_mgmt_supp :1;
+	uint8_t reserved2:1;
+} __attribute__((__packed__));
+
+struct locking_supported_feat {
+	uint8_t locking_supp:1;
+	uint8_t locking_en:1;
+	uint8_t locked:1;
+	uint8_t media_enc:1;
+	uint8_t mbr_en:1;
+	uint8_t mbr_done:1;
+	uint8_t reserved:2;
+} __attribute__((__packed__));
+
+struct opalv200_supported_feat {
+	uint16_t base_comid;
+	uint16_t comid_num;
+	uint8_t reserved1;
+	uint16_t admin_lp_auth_num;
+	uint16_t user_lp_auth_num;
+	uint8_t reserved2[7];
+} __attribute__((__packed__));
+
 struct opal_l0_feat {
 	int type;
 	union {
 		struct {
-			struct {
-				uint8_t sync_supp :1;
-				uint8_t async_supp :1;
-				uint8_t ack_nak_supp :1;
-				uint8_t buff_mgmt_supp :1;
-				uint8_t stream_supp :1;
-				uint8_t reserved1 :1;
-				uint8_t comid_mgmt_supp :1;
-				uint8_t reserved2 :1;
-			} flags;
+			struct tper_supported_feat flags;
 		} tper;
-		struct {
-			struct {
-				uint8_t locking_supp:1;
-				uint8_t locking_en:1;
-				uint8_t locked:1;
-				uint8_t media_enc:1;
-				uint8_t mbr_en:1;
-				uint8_t mbr_done:1;
-				uint8_t reserved:2;
-			} flags;
+
+		struct{
+			struct locking_supported_feat flags;
 		} locking;
-		struct {
-			uint16_t base_comid;
-			uint16_t comid_num;
-			uint16_t admin_lp_auth_num;
-			uint16_t user_lp_auth_num;
-		} opalv200;
+
+		struct opalv200_supported_feat opalv200;
 	} feat;
 };
 
@@ -222,7 +232,7 @@ struct opal_l0_disc {
 	uint32_t rev;
 	uint16_t comid;
 	struct opal_l0_feat feats[MAX_FEATURES];
-} __attribute__((__packed__)) ;
+} __attribute__((__packed__));
 
 
 struct opal_level0_header {
@@ -239,38 +249,16 @@ struct opal_level0_feat_desc {
 	uint8_t len;
 	union {
 		struct {
-			struct {
-				uint8_t sync_supp:1;
-				uint8_t async_supp:1;
-				uint8_t ack_nak_supp:1;
-				uint8_t buff_mgmt_supp:1;
-				uint8_t stream_supp:1;
-				uint8_t reserved1:1;
-				uint8_t comid_mgmt_supp:1;
-				uint8_t reserved2:1;
-			} __attribute__((__packed__)) flags;
+			struct tper_supported_feat flags;
 			uint8_t reserved[11];
 		} __attribute__((__packed__)) tper;
+
 		struct {
-			struct {
-				uint8_t locking_supp:1;
-				uint8_t locking_en:1;
-				uint8_t locked:1;
-				uint8_t media_enc:1;
-				uint8_t mbr_en:1;
-				uint8_t mbr_done:1;
-				uint8_t reserved:2;
-			} __attribute__((__packed__)) flags;
+			struct locking_supported_feat flags;
 			uint8_t reserved[11];
 		} __attribute__((__packed__)) locking;
-		struct {
-			uint16_t base_comid;
-			uint16_t comid_num;
-			uint8_t reserved1;
-			uint16_t admin_lp_auth_num;
-			uint16_t user_lp_auth_num;
-			uint8_t reserved2[7];
-		} __attribute__((__packed__)) opalv200;
+
+		struct opalv200_supported_feat opalv200;
 	} feat;
 } __attribute__((__packed__)) ;
 
@@ -307,9 +295,16 @@ struct opal_header {
 	uint8_t payload[];
 } __attribute__((__packed__));
 
+struct opal_level0_discovery {
+	struct tper_supported_feat tper;
+	struct locking_supported_feat locking;
+	struct opalv200_supported_feat opalv200;
+};
 
 int opal_init_pt(struct sed_device *dev,
 		const char *device_path);
+
+void opal_level0_discv_info_pt(struct sed_opal_level0_discovery *discvry);
 
 int opal_takeownership_pt(struct sed_device *dev, const struct sed_key *key);
 

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -17,6 +17,7 @@
 #define ARRAY_SIZE(x) ((size_t)(sizeof(x) / sizeof(x[0])))
 
 typedef int (*init)(struct sed_device *, const char *);
+typedef void (*lvl0_discv) (struct sed_opal_level0_discovery *discv);
 typedef int (*take_ownership)(struct sed_device *, const struct sed_key *);
 typedef int (*reverttper)(struct sed_device *, const struct sed_key *, bool);
 typedef int (*activate_lsp)(struct sed_device *, const struct sed_key *,
@@ -46,6 +47,7 @@ typedef void (*deinit)(struct sed_device *);
 
 struct opal_interface {
 	init init_fn;
+	lvl0_discv lvl0_discv_fn;
 	take_ownership ownership_fn;
 	reverttper revert_fn;
 	revertsp revertsp_fn;
@@ -71,6 +73,7 @@ struct opal_interface {
 #ifdef CONFIG_OPAL_DRIVER
 static struct opal_interface opal_if = {
 	.init_fn = sedopal_init,
+	.lvl0_discv_fn = NULL,
 	.ownership_fn = sedopal_takeownership,
 	.revert_fn = sedopal_reverttper,
 	.activatelsp_fn = sedopal_activatelsp,
@@ -95,6 +98,7 @@ static struct opal_interface opal_if = {
 #else
 static struct opal_interface opal_if = {
 	.init_fn	= opal_init_pt,
+	.lvl0_discv_fn	= opal_level0_discv_info_pt,
 	.ownership_fn	= opal_takeownership_pt,
 	.revert_fn	= opal_reverttper_pt,
 	.activatelsp_fn	= opal_activate_lsp_pt,
@@ -167,6 +171,16 @@ int sed_init(struct sed_device **dev, const char *dev_path)
 
 	*dev = ret;
 	return status;
+}
+
+int  sed_level0_discovery(struct sed_opal_level0_discovery *discv)
+{
+	if (curr_if->lvl0_discv_fn == NULL)
+		return -EOPNOTSUPP;
+
+	curr_if->lvl0_discv_fn(discv);
+
+	return 0;
 }
 
 void sed_deinit(struct sed_device *dev)


### PR DESCRIPTION
This patch aims at providing an cli that helps the user to
obtain the device info via level0 discovery.
This works fine only with NVMe passthru mechanism.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>