### PR TITLE
sedcli: Extend the level0 Discovery features

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -42,18 +42,48 @@ struct sed_locking_supported_feat {
 	uint8_t reserved:2;
 } __attribute__((__packed__));
 
+struct sed_geometry_supported_feat {
+	struct {
+		uint8_t align:1;
+		uint8_t rsvd1:7;
+	} __attribute__((__packed__)) rsvd_align;
+	uint8_t rsvd2[7];
+	uint32_t logical_blk_sz;
+	uint64_t alignmnt_granlrty;
+	uint64_t lowest_aligned_lba;
+} __attribute__((__packed__));
+
+struct sed_datastr_table_supported_feat {
+	uint16_t max_num_datastr_tbls;
+	uint32_t max_total_size_datstr_tbls;
+	uint32_t datastr_tbl_size_align;
+} __attribute__((__packed__));
+
+struct sed_opalv100_supported_feat {
+	uint16_t v1_base_comid;
+	uint16_t v1_comid_num;
+} __attribute__((__packed__));
+
 struct sed_opalv200_supported_feat {
 	uint16_t base_comid;
 	uint16_t comid_num;
-	uint8_t reserved1;
+	struct {
+		uint8_t range_crossing:1;
+		uint8_t rsvd1:7;
+	} __attribute__((__packed__)) rangecross_rsvd;
 	uint16_t admin_lp_auth_num;
 	uint16_t user_lp_auth_num;
-	uint8_t reserved2[7];
+	uint8_t init_pin;
+	uint8_t revert_pin;
+	uint8_t reserved2[5];
 } __attribute__((__packed__));
 
 struct sed_opal_level0_discovery {
 	struct sed_tper_supported_feat sed_tper;
 	struct sed_locking_supported_feat sed_locking;
+	struct sed_geometry_supported_feat sed_geo;
+	struct sed_datastr_table_supported_feat sed_datastr;
+	struct sed_opalv100_supported_feat sed_opalv100;
 	struct sed_opalv200_supported_feat sed_opalv200;
 };
 

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -185,6 +185,21 @@ static void check_locking_feat(void *feat)
 	memcpy(&discv->locking, (struct locking_supported_feat *)feat, sizeof(struct locking_supported_feat));
 }
 
+static void check_geometry_feat(void *feat)
+{
+	memcpy(&discv->geo, (struct geometry_supported_feat *)feat, sizeof(struct geometry_supported_feat));
+}
+
+static void check_datastr_feat(void *feat)
+{
+	memcpy(&discv->datastr, (struct datastr_table_supported_feat *)feat, sizeof(struct datastr_table_supported_feat));
+}
+
+static void check_opalv100_feat(void *feat)
+{
+	memcpy(&discv->opalv100, (struct opalv100_supported_feat *)feat, sizeof(struct opalv100_supported_feat));
+}
+
 static void check_opalv200_feat(void *feat)
 {
 	memcpy(&discv->opalv200, (struct opalv200_supported_feat *)feat, sizeof(struct opalv200_supported_feat));
@@ -250,12 +265,14 @@ static int opal_level0_disc_pt(int fd, struct opal_device *dev)
 		case OPAL_FEAT_GEOMETRY:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
+			check_geometry_feat(&desc->feat.geo);
 
 			feat_no++;
 			break;
 		case OPAL_FEAT_DATASTORE:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
+			check_datastr_feat(&desc->feat.datastr.datastr_tbl);
 
 			feat_no++;
 			break;
@@ -268,6 +285,7 @@ static int opal_level0_disc_pt(int fd, struct opal_device *dev)
 		case OPAL_FEAT_OPALV100:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
+			check_opalv100_feat(&desc->feat.opalv100);
 
 			feat_no++;
 			break;

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -203,13 +203,40 @@ struct locking_supported_feat {
 	uint8_t reserved:2;
 } __attribute__((__packed__));
 
+struct geometry_supported_feat {
+	struct {
+		uint8_t align:1;
+		uint8_t rsvd1:7;
+	} __attribute__((__packed__)) rsvd_align;
+	uint8_t rsvd2[7];
+	uint32_t logical_blk_sz;
+	uint64_t alignmnt_granlrty;
+	uint64_t lowest_aligned_lba;
+} __attribute__((__packed__));
+
+struct datastr_table_supported_feat {
+	uint16_t max_num_datastr_tbls;
+	uint32_t max_total_size_datstr_tbls;
+	uint32_t datastr_tbl_size_align;
+} __attribute__((__packed__));
+
+struct opalv100_supported_feat {
+	uint16_t v1_base_comid;
+	uint16_t v1_comid_num;
+} __attribute__((__packed__));
+
 struct opalv200_supported_feat {
 	uint16_t base_comid;
 	uint16_t comid_num;
-	uint8_t reserved1;
+	struct {
+		uint8_t range_crossing:1;
+		uint8_t rsvd1:7;
+	} __attribute__((__packed__)) rangecross_rsvd;
 	uint16_t admin_lp_auth_num;
 	uint16_t user_lp_auth_num;
-	uint8_t reserved2[7];
+	uint8_t init_pin;
+	uint8_t revert_pin;
+	uint8_t reserved2[5];
 } __attribute__((__packed__));
 
 struct opal_l0_feat {
@@ -223,6 +250,12 @@ struct opal_l0_feat {
 			struct locking_supported_feat flags;
 		} locking;
 
+		struct geometry_supported_feat geo;
+
+		struct datastr_table_supported_feat datastr;
+
+		struct opalv100_supported_feat opalv100;
+
 		struct opalv200_supported_feat opalv200;
 	} feat;
 };
@@ -233,7 +266,6 @@ struct opal_l0_disc {
 	uint16_t comid;
 	struct opal_l0_feat feats[MAX_FEATURES];
 } __attribute__((__packed__));
-
 
 struct opal_level0_header {
 	uint32_t len;
@@ -257,6 +289,15 @@ struct opal_level0_feat_desc {
 			struct locking_supported_feat flags;
 			uint8_t reserved[11];
 		} __attribute__((__packed__)) locking;
+
+		struct {
+			uint8_t reserved[2];
+			struct datastr_table_supported_feat datastr_tbl;
+		} datastr;
+
+		struct geometry_supported_feat geo;
+
+		struct opalv100_supported_feat opalv100;
 
 		struct opalv200_supported_feat opalv200;
 	} feat;
@@ -298,6 +339,9 @@ struct opal_header {
 struct opal_level0_discovery {
 	struct tper_supported_feat tper;
 	struct locking_supported_feat locking;
+	struct geometry_supported_feat geo;
+	struct datastr_table_supported_feat datastr;
+	struct opalv100_supported_feat opalv100;
 	struct opalv200_supported_feat opalv200;
 };
 

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -430,8 +430,8 @@ static void sed_discv_print_normal(struct sed_opal_level0_discovery *discv, cons
 
 		/* Printing Geometry Supported Features*/
 		sedcli_printf(LOG_INFO, "\nSED GEOMETRY FEATURES SUPPORTED\n");
-		sedcli_printf(LOG_INFO, "\tALIGN                 : %s\n", discv->sed_geo.rsvd_align.align ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tLogica Block Size     : %d\n", be32toh(discv->sed_geo.logical_blk_sz));
+		sedcli_printf(LOG_INFO, "\tAlignment required    : %s\n", discv->sed_geo.rsvd_align.align ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tLogical Block Size    : %d\n", be32toh(discv->sed_geo.logical_blk_sz));
 		sedcli_printf(LOG_INFO, "\tAlignment Granularity : %ld\n", be64toh(discv->sed_geo.alignmnt_granlrty));
 		sedcli_printf(LOG_INFO, "\tLowest Aligned LBA    : %ld\n",  be64toh(discv->sed_geo.lowest_aligned_lba));
 
@@ -451,10 +451,10 @@ static void sed_discv_print_normal(struct sed_opal_level0_discovery *discv, cons
 		}
 
 		/* Printing Opalv200 Features */
-		sedcli_printf(LOG_INFO, "\nSED Opal v.200 FEATURES SUPPORTED\n");
+		sedcli_printf(LOG_INFO, "\nSED Opal v2.00 FEATURES SUPPORTED\n");
 		sedcli_printf(LOG_INFO, "\tBase ComID                      : %d\n", be16toh(discv->sed_opalv200.base_comid));
 		sedcli_printf(LOG_INFO, "\tNumber of ComIDs                : %d\n", be16toh(discv->sed_opalv200.comid_num));
-		sedcli_printf(LOG_INFO, "\tRange Crossing Behavior         : %s\n", discv->sed_opalv200.rangecross_rsvd.range_crossing ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tRange Crossing Behavior         : %d\n", discv->sed_opalv200.rangecross_rsvd.range_crossing ? 0 : 1);
 		sedcli_printf(LOG_INFO, "\tAdmin Authorities LSP Supported : %d\n", be16toh(discv->sed_opalv200.admin_lp_auth_num));
 		sedcli_printf(LOG_INFO, "\tUser Authorities LSP Supported  : %d\n", be16toh(discv->sed_opalv200.user_lp_auth_num));
 		sedcli_printf(LOG_INFO, "\tInitial PIN                     : %d\n", discv->sed_opalv200.init_pin);

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -411,29 +411,54 @@ static void sed_discv_print_normal(struct sed_opal_level0_discovery *discv, cons
 		return;
 	} else {
 		/* Printing the TPer Features */
-		sedcli_printf(LOG_INFO, "\nSED TPER FEATURES SUPPORTED:\n");
-		sedcli_printf(LOG_INFO, "\tSYNC_SUPP       : %s\n", discv->sed_tper.sync_supp ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tASYNC_SUPP      : %s\n", discv->sed_tper.async_supp ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tACK_NAK_SUPP    : %s\n", discv->sed_tper.ack_nak_supp ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tBUFF_MGMT_SUPP  : %s\n", discv->sed_tper.buff_mgmt_supp ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tSTREAM_SUPP     : %s\n", discv->sed_tper.stream_supp ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tCOMID_MGMT_SUPP : %s\n", discv->sed_tper.comid_mgmt_supp ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\nSED TPER FEATURES SUPPORTED\n");
+		sedcli_printf(LOG_INFO, "\tSync Supported        : %s\n", discv->sed_tper.sync_supp ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tAsync Supported       : %s\n", discv->sed_tper.async_supp ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tACK/NAK Supported     : %s\n", discv->sed_tper.ack_nak_supp ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tBuffer Mgmt Supported : %s\n", discv->sed_tper.buff_mgmt_supp ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tStreaming Supported   : %s\n", discv->sed_tper.stream_supp ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tComID Mgmt Supported  : %s\n", discv->sed_tper.comid_mgmt_supp ? "Y" : "N");
 
 		/* Printing the Locking Feature */
-		sedcli_printf(LOG_INFO, "\nSED LOCKING FEATURES SUPPORTED: \n");
-		sedcli_printf(LOG_INFO, "\tLOCKING_SUPP : %s\n", discv->sed_locking.locking_supp ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tLOCKING_EN   : %s\n", discv->sed_locking.locking_en ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tLOCKED       : %s\n", discv->sed_locking.locked ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tMEDIA_ENC    : %s\n", discv->sed_locking.media_enc ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tMBR_EN       : %s\n", discv->sed_locking.mbr_en ? "Y" : "N");
-		sedcli_printf(LOG_INFO, "\tMBR_DONE     : %s\n", discv->sed_locking.mbr_done ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\nSED LOCKING FEATURES SUPPORTED\n");
+		sedcli_printf(LOG_INFO, "\tLocking Supported : %s\n", discv->sed_locking.locking_supp ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tLocking Enabled   : %s\n", discv->sed_locking.locking_en ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tLocked            : %s\n", discv->sed_locking.locked ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tMedia Encryption  : %s\n", discv->sed_locking.media_enc ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tMBR Enabled       : %s\n", discv->sed_locking.mbr_en ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tMBR Done          : %s\n", discv->sed_locking.mbr_done ? "Y" : "N");
+
+		/* Printing Geometry Supported Features*/
+		sedcli_printf(LOG_INFO, "\nSED GEOMETRY FEATURES SUPPORTED\n");
+		sedcli_printf(LOG_INFO, "\tALIGN                 : %s\n", discv->sed_geo.rsvd_align.align ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tLogica Block Size     : %d\n", be32toh(discv->sed_geo.logical_blk_sz));
+		sedcli_printf(LOG_INFO, "\tAlignment Granularity : %ld\n", be64toh(discv->sed_geo.alignmnt_granlrty));
+		sedcli_printf(LOG_INFO, "\tLowest Aligned LBA    : %ld\n",  be64toh(discv->sed_geo.lowest_aligned_lba));
+
+		/* Printing Datastore Fetaures */
+		sedcli_printf(LOG_INFO, "\nSED DATASTORE FEATURES SUPPORTED\n");
+		sedcli_printf(LOG_INFO, "\tMax DataStore tables       : %d\n", be16toh(discv->sed_datastr.max_num_datastr_tbls));
+		sedcli_printf(LOG_INFO, "\tMax size DataStore tables  : %d\n", be32toh(discv->sed_datastr.max_total_size_datstr_tbls));
+		sedcli_printf(LOG_INFO, "\tDataStore table size align : %d\n", be32toh(discv->sed_datastr.datastr_tbl_size_align));
+
+		/* Printing Opalv100 Features */
+		if (!be16toh(discv->sed_opalv100.v1_base_comid))
+			sedcli_printf(LOG_INFO, "\nSED Opal v1.00 FEATURES NOT SUPPORTED\n");
+		else {
+			sedcli_printf(LOG_INFO, "\nSED Opal v1.00 FEATURES SUPPORTED\n");
+			sedcli_printf(LOG_INFO, "\tBase ComID       : %d\n", be16toh(discv->sed_opalv100.v1_base_comid));
+			sedcli_printf(LOG_INFO, "\tNumber of ComIDs : %d\n", be16toh(discv->sed_opalv100.v1_comid_num));
+		}
 
 		/* Printing Opalv200 Features */
-		sedcli_printf(LOG_INFO, "\nSED Opalv200 FEATURES SUPPORTED: \n");
-		sedcli_printf(LOG_INFO, "\tBASE_COMID        : %d\n", be16toh(discv->sed_opalv200.base_comid));
-		sedcli_printf(LOG_INFO, "\tCOMID_NUM         : %d\n", be16toh(discv->sed_opalv200.comid_num));
-		sedcli_printf(LOG_INFO, "\tADMIN_LP_AUTH_NUM : %d\n", be16toh(discv->sed_opalv200.admin_lp_auth_num));
-		sedcli_printf(LOG_INFO, "\tUSER_LP_AUTH_NUM  : %d\n\n", be16toh(discv->sed_opalv200.user_lp_auth_num));
+		sedcli_printf(LOG_INFO, "\nSED Opal v.200 FEATURES SUPPORTED\n");
+		sedcli_printf(LOG_INFO, "\tBase ComID                      : %d\n", be16toh(discv->sed_opalv200.base_comid));
+		sedcli_printf(LOG_INFO, "\tNumber of ComIDs                : %d\n", be16toh(discv->sed_opalv200.comid_num));
+		sedcli_printf(LOG_INFO, "\tRange Crossing Behavior         : %s\n", discv->sed_opalv200.rangecross_rsvd.range_crossing ? "Y" : "N");
+		sedcli_printf(LOG_INFO, "\tAdmin Authorities LSP Supported : %d\n", be16toh(discv->sed_opalv200.admin_lp_auth_num));
+		sedcli_printf(LOG_INFO, "\tUser Authorities LSP Supported  : %d\n", be16toh(discv->sed_opalv200.user_lp_auth_num));
+		sedcli_printf(LOG_INFO, "\tInitial PIN                     : %d\n", discv->sed_opalv200.init_pin);
+		sedcli_printf(LOG_INFO, "\tRevert PIN                      : %d\n\n", discv->sed_opalv200.revert_pin);
 	}
 }
 


### PR DESCRIPTION
This patch aims at extending the present Level0 Discovery
structures and print them correspondingly in the CLI.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>