### PR TITLE
sedcli: Prevent Double free in deinit function

### DIFF
--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -316,6 +316,7 @@ void opal_deinit_pt(struct sed_device *dev)
 {
 	if (dev->fd != 0) {
 		close(dev->fd);
+		dev->fd = 0;
 	}
 
 	if (dev->priv != NULL) {
@@ -325,6 +326,7 @@ void opal_deinit_pt(struct sed_device *dev)
 
 	if (discv != NULL) {
 		free(discv);
+		discv = NULL;
 	}
 
 	opal_parser_deinit();

--- a/src/lib/opal_parser.c
+++ b/src/lib/opal_parser.c
@@ -52,8 +52,10 @@ int opal_parser_init(void)
 
 void opal_parser_deinit(void)
 {
-	if (token_storage != NULL)
+	if (token_storage != NULL) {
 		free(token_storage);
+		token_storage = NULL;
+	}
 }
 
 static int append_short_atom_bytes_header(uint8_t *buf, size_t len, int data_len)

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -186,10 +186,10 @@ int  sed_level0_discovery(struct sed_opal_level0_discovery *discv)
 void sed_deinit(struct sed_device *dev)
 {
 	if (dev != NULL) {
-		curr_if->deinit_fn(dev);
+		if (dev->fd)
+			curr_if->deinit_fn(dev);
 
 		memset(dev, 0, sizeof(*dev));
-
 		free(dev);
 	}
 }

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -186,9 +186,7 @@ int  sed_level0_discovery(struct sed_opal_level0_discovery *discv)
 void sed_deinit(struct sed_device *dev)
 {
 	if (dev != NULL) {
-		if (dev->fd)
-			curr_if->deinit_fn(dev);
-
+		curr_if->deinit_fn(dev);
 		memset(dev, 0, sizeof(*dev));
 		free(dev);
 	}


### PR DESCRIPTION
The current code leads to an error(double free) when there
is an error during initialization (especially with the nvme-pt I/F).

This patch fixes the double free issue. Also, it was successfully
tested using valgrind tool for any memory leaks.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>