### PR TITLE
libsed: change list_lr to return LRs array instead of printing them

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -13,6 +13,8 @@
 
 #define SED_MAX_KEY_LEN (32)
 
+#define SED_OPAL_MAX_LRS 9
+
 enum SED_ACCESS_TYPE {
 	SED_RO_ACCESS = 1 << 0,
 	SED_RW_ACCESS = 1 << 1,
@@ -90,6 +92,21 @@ struct sed_opal_level0_discovery {
 struct sed_key {
 	uint8_t key[SED_MAX_KEY_LEN];
 	uint8_t len;
+};
+
+struct sed_opal_lockingrange {
+	size_t start;
+	size_t length;
+	uint8_t lr_id:4;
+	uint8_t read_locked:1;
+	uint8_t write_locked:1;
+	uint8_t rle:1;
+	uint8_t wle:1;
+};
+
+struct sed_opal_lockingranges {
+	struct sed_opal_lockingrange lrs[SED_OPAL_MAX_LRS];
+	uint8_t lr_num;
 };
 
 enum sed_status {
@@ -184,6 +201,17 @@ int sed_revertlsp(struct sed_device *dev, const struct sed_key *key, bool keep_g
  */
 int sed_setpw(struct sed_device *dev, const struct sed_key *old_key,
 		const struct sed_key *new_key);
+
+/**
+ * Get list of locking ranges.
+ * @param dev			the device to operate on
+ * @param key   		the Admin1 password
+ * @param lrs			array of discovered locking ranges
+ *
+ * @return OPAL_SUCCESS on success
+ */
+int sed_list_lr(struct sed_device *dev, const struct sed_key *key,
+                struct sed_opal_lockingranges *lrs);
 
 /**
  *

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -398,7 +398,8 @@ int opal_ds_anybody_write(struct sed_device *, uint8_t *from, uint32_t size, uin
 
 int opal_ds_add_anybody_get(struct sed_device *dev, const char *key, uint8_t key_len);
 
-int opal_list_lr_pt(struct sed_device *dev, const char *password, uint8_t key_len);
+int opal_list_lr_pt(struct sed_device *dev, const struct sed_key *key,
+		    struct sed_opal_lockingranges *lrs);
 
 void opal_deinit_pt(struct sed_device *dev);
 

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -42,7 +42,8 @@ typedef int (*ds_admin_write)(struct sed_device *, const char *, uint8_t, const 
 typedef int (*ds_admin_read)(struct sed_device *, const char *, uint8_t, uint8_t *, uint32_t, uint32_t);
 typedef int (*ds_anybody_read)(struct sed_device *, uint8_t *, uint32_t, uint32_t);
 typedef int (*ds_anybody_write)(struct sed_device *, uint8_t *, uint32_t, uint32_t);
-typedef int (*list_lr)(struct sed_device *, const char *, uint8_t);
+typedef int (*list_lr)(struct sed_device *, const struct sed_key *,
+		       struct sed_opal_lockingranges *);
 typedef void (*deinit)(struct sed_device *);
 
 struct opal_interface {
@@ -329,12 +330,13 @@ int sed_ds_add_anybody_get(struct sed_device *dev, const char *key, uint8_t key_
 	return curr_if->ds_add_anybody_get_fn(dev, key, key_len);
 }
 
-int sed_list_lr(struct sed_device *dev, const char *key, uint8_t key_len)
+int sed_list_lr(struct sed_device *dev, const struct sed_key *key,
+		struct sed_opal_lockingranges *lrs)
 {
 	if (curr_if->list_lr_fn == NULL)
 		return -EOPNOTSUPP;
 
-	return curr_if->list_lr_fn(dev, key, key_len);
+	return curr_if->list_lr_fn(dev, key, lrs);
 }
 
 const char *sed_error_text(int sed_status)


### PR DESCRIPTION
Libsed function used to get list of OPAL locking ranges would be more useful if it returned LR data to the caller instead of print it on standard output.
This pull request consists of 2 patches:
1. Change list_lr to update provided array with LR information.
2. Add new option to sedcli to print locking ranges status.