### PR TITLE
libsed: expose get_msid function in libsed library

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -141,6 +141,11 @@ int sed_key_init(struct sed_key *disk_key, const char *key, const uint8_t key_le
 /**
  *
  */
+int sed_get_msid_pin(struct sed_device *dev, struct sed_key *msid_pin);
+
+/**
+ *
+ */
 int sed_takeownership(struct sed_device *dev, const struct sed_key *key);
 
 /**

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -352,6 +352,8 @@ void opal_level0_discv_info_pt(struct sed_opal_level0_discovery *discvry);
 
 int opal_takeownership_pt(struct sed_device *dev, const struct sed_key *key);
 
+int opal_get_msid_pin_pt(struct sed_device *dev, struct sed_key *msid_pin);
+
 int opal_reverttper_pt(struct sed_device *dev, const struct sed_key *key, bool psid);
 
 int opal_revertlsp_pt(struct sed_device *dev, const struct sed_key *key,

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -19,6 +19,7 @@
 typedef int (*init)(struct sed_device *, const char *);
 typedef void (*lvl0_discv) (struct sed_opal_level0_discovery *discv);
 typedef int (*take_ownership)(struct sed_device *, const struct sed_key *);
+typedef int (*get_msid_pin)(struct sed_device *, struct sed_key *);
 typedef int (*reverttper)(struct sed_device *, const struct sed_key *, bool);
 typedef int (*activate_lsp)(struct sed_device *, const struct sed_key *,
 			char *, bool);
@@ -49,6 +50,7 @@ struct opal_interface {
 	init init_fn;
 	lvl0_discv lvl0_discv_fn;
 	take_ownership ownership_fn;
+	get_msid_pin get_msid_pin_fn;
 	reverttper revert_fn;
 	revertsp revertsp_fn;
 	activate_lsp activatelsp_fn;
@@ -75,6 +77,7 @@ static struct opal_interface opal_if = {
 	.init_fn = sedopal_init,
 	.lvl0_discv_fn = NULL,
 	.ownership_fn = sedopal_takeownership,
+	.get_msid_pin_fn = NULL,
 	.revert_fn = sedopal_reverttper,
 	.activatelsp_fn = sedopal_activatelsp,
 	.revertsp_fn = NULL,
@@ -100,6 +103,7 @@ static struct opal_interface opal_if = {
 	.init_fn	= opal_init_pt,
 	.lvl0_discv_fn	= opal_level0_discv_info_pt,
 	.ownership_fn	= opal_takeownership_pt,
+	.get_msid_pin_fn = opal_get_msid_pin_pt,
 	.revert_fn	= opal_reverttper_pt,
 	.activatelsp_fn	= opal_activate_lsp_pt,
 	.revertsp_fn	= opal_revertlsp_pt,
@@ -216,6 +220,14 @@ int sed_key_init(struct sed_key *auth_key, const char *key, const uint8_t key_le
 int sed_takeownership(struct sed_device *dev, const struct sed_key *key)
 {
 	return curr_if->ownership_fn(dev, key);
+}
+
+int sed_get_msid_pin(struct sed_device *dev, struct sed_key *msid_pin)
+{
+	if (curr_if->get_msid_pin_fn == NULL)
+		return -EOPNOTSUPP;
+
+	return curr_if->get_msid_pin_fn(dev, msid_pin);
 }
 
 int sed_setup_global_range(struct sed_device *dev, const struct sed_key *key)


### PR DESCRIPTION
This patch introduces get_msid function to libsed library, so it is
possible to read manufacturer default password.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@intel.com>