### PR TITLE
libsed: allow changing pin for selected authority

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -19,6 +19,21 @@ enum SED_ACCESS_TYPE {
 	SED_NO_ACCESS = 1 << 2,
 };
 
+enum SED_AUTHORITY {
+	SED_ADMIN1 = 0x0,
+	SED_USER1 = 0x01,
+	SED_USER2 = 0x02,
+	SED_USER3 = 0x03,
+	SED_USER4 = 0x04,
+	SED_USER5 = 0x05,
+	SED_USER6 = 0x06,
+	SED_USER7 = 0x07,
+	SED_USER8 = 0x08,
+	SED_USER9 = 0x09,
+	SED_SID = 0x0A,
+	SED_PSID = 0x0B,
+};
+
 struct sed_device;
 
 struct sed_tper_supported_feat {
@@ -182,7 +197,7 @@ int sed_revertlsp(struct sed_device *dev, const struct sed_key *key, bool keep_g
 /**
  *
  */
-int sed_setpw(struct sed_device *dev, const struct sed_key *old_key,
+int sed_setpw(struct sed_device *dev, enum SED_AUTHORITY auth, const struct sed_key *old_key,
 		const struct sed_key *new_key);
 
 /**

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -951,36 +951,6 @@ static int opal_get_msid(int fd, struct opal_device *dev, uint8_t *key, size_t *
 	return ret;
 }
 
-static struct opal_req_item set_sid_pwd_cmd[] = {
-	{ .type = OPAL_U8, .len = 1, .val = { .byte = OPAL_STARTNAME } },
-	{ .type = OPAL_U8, .len = 1, .val = { .byte = 1 } }, /* Values */
-	{ .type = OPAL_U8, .len = 1, .val = { .byte = OPAL_STARTLIST } },
-	{ .type = OPAL_U8, .len = 1, .val = { .byte = OPAL_STARTNAME } },
-	{ .type = OPAL_U8, .len = 1, .val = { .byte = 3 } }, /* PIN */
-	{ .type = OPAL_BYTES, .len = 1, .val = { .bytes = NULL } }, /* new key and it's length */
-	{ .type = OPAL_U8, .len = 1, .val = { .byte = OPAL_ENDNAME } },
-	{ .type = OPAL_U8, .len = 1, .val = { .byte = OPAL_ENDLIST } },
-	{ .type = OPAL_U8, .len = 1, .val = { .byte = OPAL_ENDNAME } },
-};
-
-static int opal_set_sid_pwd(int fd, struct opal_device *dev, const struct sed_key *key)
-{
-	int ret = 0;
-
-	/* Update the password */
-	set_sid_pwd_cmd[5].len = key->len;
-	set_sid_pwd_cmd[5].val.bytes = key->key;
-
-	prepare_req_buf(dev, set_sid_pwd_cmd, ARRAY_SIZE(set_sid_pwd_cmd),
-			opal_uid[OPAL_C_PIN_SID_UID], opal_method[OPAL_SET_METHOD_UID]);
-
-	ret = opal_snd_rcv_cmd_parse_chk(fd, dev, false);
-
-	opal_put_all_tokens(dev->payload.tokens, &dev->payload.len);
-
-	return ret;
-}
-
 static int opal_get_lsp_lifecycle(int fd, struct opal_device *dev)
 {
 	uint8_t lc_status;
@@ -1339,16 +1309,16 @@ static struct opal_req_item generic_pwd_cmd[] = {
 };
 
 static void generic_pwd_func(struct opal_device *dev, const struct sed_key *key,
-		const uint8_t *uid)
+		const uint8_t *auth_uid)
 {
 	generic_pwd_cmd[5].val.bytes = key->key;
 	generic_pwd_cmd[5].len = key->len;
 
 	prepare_req_buf(dev, generic_pwd_cmd, ARRAY_SIZE(generic_pwd_cmd),
-			uid, opal_method[OPAL_SET_METHOD_UID]);
+			auth_uid, opal_method[OPAL_SET_METHOD_UID]);
 }
 
-static int set_new_pwd(int fd, struct opal_device *dev, uint32_t who, uint32_t sum, uint8_t lr, const struct sed_key *new_key)
+static int set_new_admin1_pwd(int fd, struct opal_device *dev, uint32_t who, uint32_t sum, uint8_t lr, const struct sed_key *new_key)
 {
 	uint8_t uid[OPAL_UID_LENGTH];
 	int ret = 0;
@@ -1365,6 +1335,19 @@ static int set_new_pwd(int fd, struct opal_device *dev, uint32_t who, uint32_t s
 	}
 
 	generic_pwd_func(dev, new_key, uid);
+
+	ret = opal_snd_rcv_cmd_parse_chk(fd, dev, false);
+
+	opal_put_all_tokens(dev->payload.tokens, &dev->payload.len);
+
+	return ret;
+}
+
+static int opal_set_sid_pwd(int fd, struct opal_device *dev, const struct sed_key *key)
+{
+	int ret = 0;
+
+	generic_pwd_func(dev, key, opal_uid[OPAL_C_PIN_SID_UID]);
 
 	ret = opal_snd_rcv_cmd_parse_chk(fd, dev, false);
 
@@ -1923,24 +1906,34 @@ end_sessn:
 }
 
 
-int opal_set_pwd_pt(struct sed_device *dev, const struct sed_key *old_key,
+int opal_set_pwd_pt(struct sed_device *dev, enum SED_AUTHORITY auth, const struct sed_key *old_key,
 		const struct sed_key *new_key)
 {
 	struct opal_device *opal_dev;
 	int ret = 0;
 
 	if (old_key == NULL || old_key->len == 0 || new_key == NULL ||
-			new_key->len == 0) {
+			new_key->len == 0 || !(auth == SED_ADMIN1 || auth == SED_SID)) {
 		SEDCLI_DEBUG_MSG("Invalid arguments, please try again\n");
 		return -EINVAL;
 	}
 	opal_dev = dev->priv;
 
-	ret = opal_start_auth_session(dev->fd, opal_dev, 0, 0, SED_ADMIN1, old_key);
-	if (ret)
-		goto end_sessn;
+	if (auth == SED_ADMIN1) {
+		ret = opal_start_auth_session(dev->fd, opal_dev, 0, 0, SED_ADMIN1, old_key);
+		if (ret)
+			goto end_sessn;
 
-	ret = set_new_pwd(dev->fd, opal_dev, SED_ADMIN1, 0, 0, new_key);
+		ret = set_new_admin1_pwd(dev->fd, opal_dev, SED_ADMIN1, 0, 0, new_key);
+	} else {
+		ret = opal_start_generic_session(dev->fd, opal_dev, OPAL_ADMIN_SP_UID, OPAL_SID_UID, old_key);
+
+		if (ret) {
+			goto end_sessn;
+		}
+
+		ret = opal_set_sid_pwd(dev->fd, opal_dev, new_key);
+	}
 
 end_sessn:
 	opal_end_session(dev->fd, opal_dev);

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -375,7 +375,7 @@ int opal_setuplr_pt(struct sed_device *dev, const char *key, uint8_t key_len,
 int opal_lock_unlock_pt(struct sed_device *dev, const struct sed_key *key,
 		enum SED_ACCESS_TYPE lock_type);
 
-int opal_set_pwd_pt(struct sed_device *dev, const struct sed_key *old_key,
+int opal_set_pwd_pt(struct sed_device *dev, enum SED_AUTHORITY auth, const struct sed_key *old_key,
 		const struct sed_key *new_key);
 
 int opal_shadow_mbr_pt(struct sed_device *dev, const char *password,

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -32,7 +32,7 @@ typedef int (*setuplr)(struct sed_device *, const char *, uint8_t,
 			const char *, uint8_t, size_t, size_t, bool,
 			bool, bool);
 typedef int (*lock_unlock)(struct sed_device *, const struct sed_key *, enum SED_ACCESS_TYPE);
-typedef int (*set_pwd)(struct sed_device *, const struct sed_key *, const struct sed_key *);
+typedef int (*set_pwd)(struct sed_device *, enum SED_AUTHORITY, const struct sed_key *, const struct sed_key *);
 typedef int (*shadow_mbr)(struct sed_device *, const char *,
 			uint8_t, bool);
 typedef int (*eraselr)(struct sed_device *, const char *,
@@ -267,10 +267,10 @@ int sed_setuplr(struct sed_device *dev, const char *pass, uint8_t key_len,
 				   range_length, sum, RLE, WLE);
 }
 
-int sed_setpw(struct sed_device *dev, const struct sed_key *old_key,
+int sed_setpw(struct sed_device *dev, enum SED_AUTHORITY auth, const struct sed_key *old_key,
 		const struct sed_key *new_key)
 {
-	return curr_if->set_pwd_fn(dev, old_key, new_key);
+	return curr_if->set_pwd_fn(dev, auth, old_key, new_key);
 }
 
 int sed_shadowmbr(struct sed_device *dev, const char *pass, uint8_t key_len,

--- a/src/lib/sed_ioctl.c
+++ b/src/lib/sed_ioctl.c
@@ -251,13 +251,13 @@ int sedopal_shadowmbr(struct sed_device *dev, const char *password, uint8_t key_
 	return ioctl(fd, IOC_OPAL_ENABLE_DISABLE_MBR, &mbr);
 }
 
-int sedopal_setpw(struct sed_device *dev, const struct sed_key *old_key,
+int sedopal_setpw(struct sed_device *dev, enum SED_AUTHORITY auth, const struct sed_key *old_key,
 		const struct sed_key *new_key)
 {
 	struct opal_new_pw pw = { };
 	int fd = dev->fd;
 
-	if (old_key == NULL || new_key == NULL || old_key->len == 0 || new_key->len == 0) {
+	if (old_key == NULL || new_key == NULL || old_key->len == 0 || new_key->len == 0 || auth != SED_ADMIN) {
 		SEDCLI_DEBUG_MSG("Invalid arguments, please try again\n");
 		return -EINVAL;
 	}

--- a/src/lib/sed_ioctl.h
+++ b/src/lib/sed_ioctl.h
@@ -33,7 +33,7 @@ int sedopal_shadowmbr(struct sed_device *dev, const char *password,
 		uint8_t key_len,
 		bool enable_mbr);
 
-int sedopal_setpw(struct sed_device *dev, const struct sed_key *old_key,
+int sedopal_setpw(struct sed_device *dev, enum SED_AUTHORITY auth, const struct sed_key *old_key,
 		const struct sed_key *new_key);
 
 int sedopal_enable_user(struct sed_device *dev, const char *password,

--- a/src/lib/sed_util.h
+++ b/src/lib/sed_util.h
@@ -16,19 +16,6 @@ enum SED_ACCESSTYPE {
 	SED_LK = 0x04, /* 1 << 2 */
 };
 
-enum sed_user {
-	SED_ADMIN1 = 0x0,
-	SED_USER1 = 0x01,
-	SED_USER2 = 0x02,
-	SED_USER3 = 0x03,
-	SED_USER4 = 0x04,
-	SED_USER5 = 0x05,
-	SED_USER6 = 0x06,
-	SED_USER7 = 0x07,
-	SED_USER8 = 0x08,
-	SED_USER9 = 0x09,
-};
-
 struct sed_device {
 	int fd;
 	void *priv;

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -663,7 +663,7 @@ static int handle_setpw(void)
 		return ret;
 	}
 
-	ret = sed_setpw(dev, &opts->old_pwd, &opts->pwd);
+	ret = sed_setpw(dev, SED_ADMIN1, &opts->old_pwd, &opts->pwd);
 
 	print_sed_status(ret);
 


### PR DESCRIPTION
So far, it was only possible to change pin for ADMIN1 authority. This
patch extends setpw() function allowing to select authority for which
password will be changed.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@intel.com>