### PR TITLE
sedcli: Fix the print format in list_lr function

### DIFF
--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -1584,7 +1584,7 @@ static int list_lr(int fd, struct opal_device *dev, struct sed_opal_lockingrange
 		return ret;
 
 	lrs->lr_num = dev->payload.tokens[4]->vals.uint + 1;
-	SEDCLI_DEBUG_PARAM("The number of ranges discovered is: %ld\n",
+	SEDCLI_DEBUG_PARAM("The number of ranges discovered is: %d\n",
 			lrs->lr_num);
 	if (lrs->lr_num > SED_OPAL_MAX_LRS) {
 		lrs->lr_num = SED_OPAL_MAX_LRS;


### PR DESCRIPTION
The existing code has print format %ld, which breaks the build.
Fixed it to %d.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>