### PR TITLE
libsed: do zero initialization of opal_dev structure

### DIFF
--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -361,6 +361,7 @@ int opal_init_pt(struct sed_device *dev, const char *device_path)
 		ret = -ENOMEM;
 		goto init_deinit;
 	}
+	memset(opal_dev, 0, sizeof(*opal_dev));
 	dev->priv = opal_dev;
 
 	opal_dev->session.tsn = 0;

--- a/src/lib/opal_parser.c
+++ b/src/lib/opal_parser.c
@@ -303,8 +303,10 @@ void opal_put_all_tokens(struct opal_token **tokens, int *len)
 	int i;
 
 	for (i = 0; i < *len; i++) {
-		opal_put_token(tokens[i]);
-		tokens[i] = NULL;
+		if(tokens[i] != NULL) {
+			opal_put_token(tokens[i]);
+			tokens[i] = NULL;
+		}
 	}
 	*len = 0;
 }


### PR DESCRIPTION
This patch initializes opal_dev structure to prevent a crash in
opal_takeownership_pt function in case of Opal disk failures that prevent
from taking ownership