### PR TITLE
sedcli-kmip: introduction of metadata serializer/deserializer

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,23 +4,18 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-#
-# Includes dir
-#
-INCLUDES = ./include ./lib/include
-
-#
-# Flags for compilation
-#
-CFLAGS = $(patsubst %,-I%,$(INCLUDES))
-CFLAGS += $(patsubst %,-D%,$(DEFINES))
-
 ifeq (, $(filter $(MAKECMDGOALS), clean distclean))
 ifeq ("$(wildcard config.mk config.h)", "")
 $(error Run ./configure before invoking make)
 endif
 include config.mk
 endif
+
+#
+# Flags for compilation
+#
+CFLAGS += $(patsubst %,-I%,$(INCLUDES))
+CFLAGS += $(patsubst %,-D%,$(DEFINES))
 
 OBJDIR = .obj/
 LIBOBJDIR = .libobj/
@@ -43,7 +38,15 @@ OBJS = argp.o
 OBJS += sedcli_main.o
 OBJS += sedcli_util.o
 
+ifdef CONFIG_KMIP
+KMIP_OBJS = argp.o
+KMIP_OBJS += metadata_serializer.o
+endif
+
 ALL_TARGETS = $(TARGET)-static $(TARGET)-dynamic
+ifdef CONFIG_KMIP
+ALL_TARGETS += $(TARGET)-kmip.a
+endif
 
 all: $(ALL_TARGETS)
 	@ln -sf $(TARGET)-static $(TARGET)
@@ -59,6 +62,10 @@ $(TARGET)-dynamic: $(TARGET).a $(LIB).so
 $(TARGET).a: $(patsubst %,$(OBJDIR)%,$(OBJS))
 	@echo "  AR " $@
 	@ar rcs $@ $^
+
+$(TARGET)-kmip.a: $(patsubst %,$(OBJDIR)%,$(KMIP_OBJS))
+	@echo "  AR " $@
+	@ar rcs $@ $(patsubst %,$(OBJDIR)%,$(KMIP_OBJS))
 
 #
 # Static library
@@ -91,7 +98,7 @@ $(LIBOBJDIR)%.o: lib/%.c
 
 clean:
 	@echo "  CLEAN "
-	@rm -f *.a $(TARGET)-static $(TARGET)-dynamic $(TARGET) *.so*
+	@rm -f *.a $(TARGET)-kmip $(TARGET)-static $(TARGET)-dynamic $(TARGET) *.so*
 	@rm -fr $(OBJDIR) $(LIBOBJDIR)
 	@rm -f $(shell find -name \*.d) $(shell find -name \*.o)
 

--- a/src/configure
+++ b/src/configure
@@ -55,6 +55,7 @@ function common_def() {
 }
 
 function common_mk() {
+	app_config_mk "INCLUDES=./include ./lib/include"
 	app_config_mk "CFLAGS+=-include ${CONFIG_H}"
 	app_config_mk "CFLAGS+=-O2 -g -Wall -Werror -Wno-unused-function -Wno-address-of-packed-member -fstack-protector-all -std=gnu99"
 	app_config_mk "LDFLAGS+=-L."
@@ -142,6 +143,7 @@ EOF
 	if [ "${ret_code}" -eq "0" ] && test_compile "openssl" "" "-lcrypto -lssl"; then
 		print_status "KMIP support" "yes"
 		app_config_mk "CONFIG_KMIP=y"
+		app_config_mk "INCLUDES+=../libkmip"
 		app_config_mk "LDFLAGS_KMIP+=-L../libkmip -lkmip -lcrypto -lssl"
 	else
 		print_status "KMIP support" "no"

--- a/src/metadata_serializer.c
+++ b/src/metadata_serializer.c
@@ -33,87 +33,109 @@ void sedcli_metadata_free_buffer(struct sedcli_metadata *buffer)
 void sedcli_metadata_init(struct sedcli_metadata *meta, uint32_t pek_id_size,
 		uint32_t iv_size, uint32_t enc_dek_size, uint32_t tag_size)
 {
-	meta->magic_num = htole64(SEDCLI_META_MAGIC);
-	meta->version = htole32(SEDCLI_META_VERSION);
+	if (meta != NULL) {
+		meta->magic_num = htole64(SEDCLI_META_MAGIC);
+		meta->version = htole32(SEDCLI_META_VERSION);
 
-	meta->pek_id_size = htole32(pek_id_size);
-	meta->iv_size = htole32(iv_size);
-	meta->enc_dek_size = htole32(enc_dek_size);
-	meta->tag_size = htole32(tag_size);
+		meta->pek_id_size = htole32(pek_id_size);
+		meta->iv_size = htole32(iv_size);
+		meta->enc_dek_size = htole32(enc_dek_size);
+		meta->tag_size = htole32(tag_size);
+	}
 }
 
 uint8_t *sedcli_meta_get_pek_id_addr(struct sedcli_metadata *meta)
 {
-	return meta->data;
+	return meta == NULL ? NULL : meta->data;
 }
 
 uint8_t *sedcli_meta_get_iv_addr(struct sedcli_metadata *meta)
 {
 	uint32_t offset = 0;
 
-	offset += sedcli_meta_get_pek_id_size(meta);
+	if (meta != NULL) {
+		offset += sedcli_meta_get_pek_id_size(meta);
 
-	return &meta->data[offset];
+		return &meta->data[offset];
+	}
+
+	return NULL;
 }
 
 uint8_t *sedcli_meta_get_enc_dek_addr(struct sedcli_metadata *meta)
 {
 	uint32_t offset = 0;
 
-	offset += sedcli_meta_get_pek_id_size(meta);
-	offset += sedcli_meta_get_iv_size(meta);
+	if (meta != NULL) {
+		offset += sedcli_meta_get_pek_id_size(meta);
+		offset += sedcli_meta_get_iv_size(meta);
 
-	return &meta->data[offset];
+		return &meta->data[offset];
+	}
+
+	return NULL;
 }
 
 uint8_t *sedcli_meta_get_tag_addr(struct sedcli_metadata *meta)
 {
 	uint32_t offset = 0;
 
-	offset += sedcli_meta_get_pek_id_size(meta);
-	offset += sedcli_meta_get_iv_size(meta);
-	offset += sedcli_meta_get_enc_dek_size(meta);
+	if (meta != NULL) {
+		offset += sedcli_meta_get_pek_id_size(meta);
+		offset += sedcli_meta_get_iv_size(meta);
+		offset += sedcli_meta_get_enc_dek_size(meta);
 
-	return &meta->data[offset];
+		return &meta->data[offset];
+	}
+
+	return NULL;
 }
 
 uint32_t sedcli_meta_get_pek_id_size(struct sedcli_metadata *meta)
 {
-	return le32toh(meta->pek_id_size);
+	return meta != NULL ? le32toh(meta->pek_id_size) : 0;
 }
 
 void sedcli_meta_set_pek_id_size(struct sedcli_metadata *meta, uint32_t pek_id_size)
 {
-	meta->pek_id_size = htole32(pek_id_size);
+	if (meta != NULL) {
+		meta->pek_id_size = htole32(pek_id_size);
+	}
 }
 
 uint32_t sedcli_meta_get_iv_size(struct sedcli_metadata *meta)
 {
-	return le32toh(meta->iv_size);
+	return meta != NULL ? le32toh(meta->iv_size) : 0;
 }
 
 void sedcli_meta_set_iv_size(struct sedcli_metadata *meta, uint32_t iv_size)
 {
-	meta->iv_size = htole32(iv_size);
+	if (meta != NULL) {
+		meta->iv_size = htole32(iv_size);
+	}
 }
 
 uint32_t sedcli_meta_get_enc_dek_size(struct sedcli_metadata *meta)
 {
-	return le32toh(meta->enc_dek_size);
+	return meta != NULL ? le32toh(meta->enc_dek_size) : 0;
 }
 
 void sedcli_meta_set_enc_dek_size(struct sedcli_metadata *meta, uint32_t enc_dek_size)
 {
-	meta->enc_dek_size = htole32(enc_dek_size);
+	if (meta != NULL) {
+		meta->enc_dek_size = htole32(enc_dek_size);
+	}
 }
 
 uint32_t sedcli_meta_get_tag_size(struct sedcli_metadata *meta)
 {
-	return le32toh(meta->tag_size);
+	return meta != NULL ? le32toh(meta->tag_size) : 0;
 }
 
 void sedcli_meta_set_tag_size(struct sedcli_metadata *meta, uint32_t tag_size)
 {
-	meta->tag_size = htole32(tag_size);
+	if (meta != NULL) {
+		meta->tag_size = htole32(tag_size);
+	}
 }
 

--- a/src/metadata_serializer.c
+++ b/src/metadata_serializer.c
@@ -13,9 +13,8 @@ struct sedcli_metadata *sedcli_metadata_alloc_buffer()
 	uint8_t *buffer;
 
 	buffer = malloc(SEDCLI_METADATA_SIZE);
-	if (buffer == NULL) {
+	if (!buffer)
 		return NULL;
-	}
 
 	memset(buffer, 0, SEDCLI_METADATA_SIZE);
 
@@ -24,24 +23,26 @@ struct sedcli_metadata *sedcli_metadata_alloc_buffer()
 
 void sedcli_metadata_free_buffer(struct sedcli_metadata *buffer)
 {
-	if (buffer != NULL) {
-		memset(buffer, 0, SEDCLI_METADATA_SIZE);
-		free(buffer);
-	}
+	if (!buffer)
+		return;
+
+	memset(buffer, 0, SEDCLI_METADATA_SIZE);
+	free(buffer);
 }
 
 void sedcli_metadata_init(struct sedcli_metadata *meta, uint32_t pek_id_size,
 		uint32_t iv_size, uint32_t enc_dek_size, uint32_t tag_size)
 {
-	if (meta != NULL) {
-		meta->magic_num = htole64(SEDCLI_META_MAGIC);
-		meta->version = htole32(SEDCLI_META_VERSION);
+	if (!meta)
+		return;
 
-		meta->pek_id_size = htole32(pek_id_size);
-		meta->iv_size = htole32(iv_size);
-		meta->enc_dek_size = htole32(enc_dek_size);
-		meta->tag_size = htole32(tag_size);
-	}
+	meta->magic_num = htole64(SEDCLI_META_MAGIC);
+	meta->version = htole32(SEDCLI_META_VERSION);
+
+	meta->pek_id_size = htole32(pek_id_size);
+	meta->iv_size = htole32(iv_size);
+	meta->enc_dek_size = htole32(enc_dek_size);
+	meta->tag_size = htole32(tag_size);
 }
 
 uint8_t *sedcli_meta_get_pek_id_addr(struct sedcli_metadata *meta)
@@ -53,42 +54,39 @@ uint8_t *sedcli_meta_get_iv_addr(struct sedcli_metadata *meta)
 {
 	uint32_t offset = 0;
 
-	if (meta != NULL) {
-		offset += sedcli_meta_get_pek_id_size(meta);
+	if (!meta)
+		return NULL;
 
-		return &meta->data[offset];
-	}
+	offset += sedcli_meta_get_pek_id_size(meta);
 
-	return NULL;
+	return &meta->data[offset];
 }
 
 uint8_t *sedcli_meta_get_enc_dek_addr(struct sedcli_metadata *meta)
 {
 	uint32_t offset = 0;
 
-	if (meta != NULL) {
-		offset += sedcli_meta_get_pek_id_size(meta);
-		offset += sedcli_meta_get_iv_size(meta);
+	if (!meta)
+		return NULL;
 
-		return &meta->data[offset];
-	}
+	offset += sedcli_meta_get_pek_id_size(meta);
+	offset += sedcli_meta_get_iv_size(meta);
 
-	return NULL;
+	return &meta->data[offset];
 }
 
 uint8_t *sedcli_meta_get_tag_addr(struct sedcli_metadata *meta)
 {
 	uint32_t offset = 0;
 
-	if (meta != NULL) {
-		offset += sedcli_meta_get_pek_id_size(meta);
-		offset += sedcli_meta_get_iv_size(meta);
-		offset += sedcli_meta_get_enc_dek_size(meta);
+	if (!meta)
+		return NULL;
 
-		return &meta->data[offset];
-	}
+	offset += sedcli_meta_get_pek_id_size(meta);
+	offset += sedcli_meta_get_iv_size(meta);
+	offset += sedcli_meta_get_enc_dek_size(meta);
 
-	return NULL;
+	return &meta->data[offset];
 }
 
 uint32_t sedcli_meta_get_pek_id_size(struct sedcli_metadata *meta)
@@ -98,9 +96,10 @@ uint32_t sedcli_meta_get_pek_id_size(struct sedcli_metadata *meta)
 
 void sedcli_meta_set_pek_id_size(struct sedcli_metadata *meta, uint32_t pek_id_size)
 {
-	if (meta != NULL) {
-		meta->pek_id_size = htole32(pek_id_size);
-	}
+	if (!meta)
+		return;
+
+	meta->pek_id_size = htole32(pek_id_size);
 }
 
 uint32_t sedcli_meta_get_iv_size(struct sedcli_metadata *meta)
@@ -110,9 +109,10 @@ uint32_t sedcli_meta_get_iv_size(struct sedcli_metadata *meta)
 
 void sedcli_meta_set_iv_size(struct sedcli_metadata *meta, uint32_t iv_size)
 {
-	if (meta != NULL) {
-		meta->iv_size = htole32(iv_size);
-	}
+	if (!meta)
+		return ;
+
+	meta->iv_size = htole32(iv_size);
 }
 
 uint32_t sedcli_meta_get_enc_dek_size(struct sedcli_metadata *meta)
@@ -122,9 +122,10 @@ uint32_t sedcli_meta_get_enc_dek_size(struct sedcli_metadata *meta)
 
 void sedcli_meta_set_enc_dek_size(struct sedcli_metadata *meta, uint32_t enc_dek_size)
 {
-	if (meta != NULL) {
-		meta->enc_dek_size = htole32(enc_dek_size);
-	}
+	if (!meta)
+		return ;
+
+	meta->enc_dek_size = htole32(enc_dek_size);
 }
 
 uint32_t sedcli_meta_get_tag_size(struct sedcli_metadata *meta)
@@ -134,8 +135,9 @@ uint32_t sedcli_meta_get_tag_size(struct sedcli_metadata *meta)
 
 void sedcli_meta_set_tag_size(struct sedcli_metadata *meta, uint32_t tag_size)
 {
-	if (meta != NULL) {
-		meta->tag_size = htole32(tag_size);
-	}
+	if (!meta)
+		return ;
+
+	meta->tag_size = htole32(tag_size);
 }
 

--- a/src/metadata_serializer.c
+++ b/src/metadata_serializer.c
@@ -1,0 +1,119 @@
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <endian.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "metadata_serializer.h"
+
+struct sedcli_metadata *sedcli_metadata_alloc_buffer()
+{
+	uint8_t *buffer;
+
+	buffer = malloc(SEDCLI_METADATA_SIZE);
+	if (buffer == NULL) {
+		return NULL;
+	}
+
+	memset(buffer, 0, SEDCLI_METADATA_SIZE);
+
+	return (struct sedcli_metadata *)buffer;
+}
+
+void sedcli_metadata_free_buffer(struct sedcli_metadata *buffer)
+{
+	if (buffer != NULL) {
+		memset(buffer, 0, SEDCLI_METADATA_SIZE);
+		free(buffer);
+	}
+}
+
+void sedcli_metadata_init(struct sedcli_metadata *meta, uint32_t pek_id_size,
+		uint32_t iv_size, uint32_t enc_dek_size, uint32_t tag_size)
+{
+	meta->magic_num = htole64(SEDCLI_META_MAGIC);
+	meta->version = htole32(SEDCLI_META_VERSION);
+
+	meta->pek_id_size = htole32(pek_id_size);
+	meta->iv_size = htole32(iv_size);
+	meta->enc_dek_size = htole32(enc_dek_size);
+	meta->tag_size = htole32(tag_size);
+}
+
+uint8_t *sedcli_meta_get_pek_id_addr(struct sedcli_metadata *meta)
+{
+	return meta->data;
+}
+
+uint8_t *sedcli_meta_get_iv_addr(struct sedcli_metadata *meta)
+{
+	uint32_t offset = 0;
+
+	offset += sedcli_meta_get_pek_id_size(meta);
+
+	return &meta->data[offset];
+}
+
+uint8_t *sedcli_meta_get_enc_dek_addr(struct sedcli_metadata *meta)
+{
+	uint32_t offset = 0;
+
+	offset += sedcli_meta_get_pek_id_size(meta);
+	offset += sedcli_meta_get_iv_size(meta);
+
+	return &meta->data[offset];
+}
+
+uint8_t *sedcli_meta_get_tag_addr(struct sedcli_metadata *meta)
+{
+	uint32_t offset = 0;
+
+	offset += sedcli_meta_get_pek_id_size(meta);
+	offset += sedcli_meta_get_iv_size(meta);
+	offset += sedcli_meta_get_enc_dek_size(meta);
+
+	return &meta->data[offset];
+}
+
+uint32_t sedcli_meta_get_pek_id_size(struct sedcli_metadata *meta)
+{
+	return le32toh(meta->pek_id_size);
+}
+
+void sedcli_meta_set_pek_id_size(struct sedcli_metadata *meta, uint32_t pek_id_size)
+{
+	meta->pek_id_size = htole32(pek_id_size);
+}
+
+uint32_t sedcli_meta_get_iv_size(struct sedcli_metadata *meta)
+{
+	return le32toh(meta->iv_size);
+}
+
+void sedcli_meta_set_iv_size(struct sedcli_metadata *meta, uint32_t iv_size)
+{
+	meta->iv_size = htole32(iv_size);
+}
+
+uint32_t sedcli_meta_get_enc_dek_size(struct sedcli_metadata *meta)
+{
+	return le32toh(meta->enc_dek_size);
+}
+
+void sedcli_meta_set_enc_dek_size(struct sedcli_metadata *meta, uint32_t enc_dek_size)
+{
+	meta->enc_dek_size = htole32(enc_dek_size);
+}
+
+uint32_t sedcli_meta_get_tag_size(struct sedcli_metadata *meta)
+{
+	return le32toh(meta->tag_size);
+}
+
+void sedcli_meta_set_tag_size(struct sedcli_metadata *meta, uint32_t tag_size)
+{
+	meta->tag_size = htole32(tag_size);
+}
+

--- a/src/metadata_serializer.h
+++ b/src/metadata_serializer.h
@@ -1,0 +1,53 @@
+#ifndef _SEDCLI_METADATA_H_
+#define _SEDCLI_METADATA_H_
+
+#include <stdint.h>
+
+#define SEDCLI_META_MAGIC (0x41494C4344455341) /* "ASEDCLIA" */
+#define SEDCLI_META_VERSION 0X01
+#define SEDCLI_META_HEADER_SIZE (sizeof(uint64_t) + (4 * sizeof(uint32_t)))
+#define SEDCLI_METADATA_SIZE (512)
+
+struct sedcli_metadata {
+	uint64_t magic_num; /* 8B size */
+	uint32_t version; /* 4B size */
+	uint32_t pek_id_size; /* 4B size */
+	uint32_t iv_size; /* 4B size */
+	uint32_t enc_dek_size; /* 4B size */
+	uint32_t tag_size; /* 4B size */
+	uint8_t data[]; /* Data contains: pek_id, IV, enc_key, tag remaining piece
+	is filled with all-zeroes */
+};
+
+struct sedcli_metadata *sedcli_metadata_alloc_buffer();
+
+void sedcli_metadata_free_buffer(struct sedcli_metadata *buffer);
+
+void sedcli_metadata_init(struct sedcli_metadata *meta, uint32_t pek_id_size,
+		uint32_t iv_size, uint32_t enc_dek_size, uint32_t tag_size);
+
+uint32_t sedcli_meta_get_pek_id_size(struct sedcli_metadata *meta);
+
+void sedcli_meta_set_pek_id_size(struct sedcli_metadata *meta, uint32_t pek_id_size);
+
+uint32_t sedcli_meta_get_iv_size(struct sedcli_metadata *meta);
+
+void sedcli_meta_set_iv_size(struct sedcli_metadata *meta, uint32_t iv_size);
+
+uint32_t sedcli_meta_get_enc_dek_size(struct sedcli_metadata *meta);
+
+void sedcli_meta_set_enc_dek_size(struct sedcli_metadata *meta, uint32_t enc_dek_size);
+
+uint32_t sedcli_meta_get_tag_size(struct sedcli_metadata *meta);
+
+void sedcli_meta_set_tag_size(struct sedcli_metadata *meta, uint32_t tag_size);
+
+uint8_t *sedcli_meta_get_pek_id_addr(struct sedcli_metadata *meta);
+
+uint8_t *sedcli_meta_get_iv_addr(struct sedcli_metadata *meta);
+
+uint8_t *sedcli_meta_get_enc_dek_addr(struct sedcli_metadata *meta);
+
+uint8_t *sedcli_meta_get_tag_addr(struct sedcli_metadata *meta);
+
+#endif /* _SEDCLI_METADATA_H_ */


### PR DESCRIPTION
This patch introduces metadata serializer and deserializer for sedcli
metadata that will be stored in Opal datastore.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@intel.com>