### PR TITLE
sedcli: Avoid redundancy in start session methods

### DIFF
--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -22,6 +22,13 @@
 #include "sed_util.h"
 
 #define GENERIC_HOST_SESSION_NUM 0x41
+
+/*
+ * TSM SHALL NOT assign any TSN in the range 0 to 4095 to a regular session.
+ * These TSNs are reserved by TCG for special sessions
+ */
+#define RSVD_TPER_SESSION_NUM	(4096)
+
 #define OPAL_SUCCESS (0)
 
 #define MAX_FEATURES 64


### PR DESCRIPTION
This patch eliminates the redundancy in start session methods
Like the usage of command struct array, preparing session buffer and
validating the session.
With a few minor tweaks in the check for session validity.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>