### PR TITLE
sedcli: adding missing license headers

### DIFF
--- a/src/metadata_serializer.c
+++ b/src/metadata_serializer.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>

--- a/src/metadata_serializer.h
+++ b/src/metadata_serializer.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
 #ifndef _SEDCLI_METADATA_H_
 #define _SEDCLI_METADATA_H_
 

--- a/src/sedcli_util.c
+++ b/src/sedcli_util.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
 #include <stdio.h>
 #include <stdint.h>
 #include <termios.h>

--- a/src/sedcli_util.h
+++ b/src/sedcli_util.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
 #ifndef _SEDCLI_UTIL_H_
 #define _SEDCLI_UTIL_H_
 


### PR DESCRIPTION
This patch adds missing license headers to c header and source files.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@intel.com>