### PR TITLE
sedcli-kmip: added udev rules to auto provision and auto unlock

### DIFF
--- a/lib/udev/rules.d/63-sedcli.rules
+++ b/lib/udev/rules.d/63-sedcli.rules
@@ -1,0 +1,24 @@
+SUBSYSTEM!="block", GOTO="sedcli_end"
+KERNEL!="nvme*[0-9]n*[0-9]", GOTO="sedcli_end"
+ACTION!="add", GOTO="sedcli_end"
+ENV{DEVTYPE}!="disk", GOTO="sedcli_end"
+
+# Perform Discovery to detect if disk is SED and its state
+IMPORT{program}="/usr/sbin/sedcli -D -d $env{DEVNAME} -f udev"
+
+ENV{DEV_SED_COMPATIBLE}=="ENABLED", GOTO="check_sedcli_lock"
+ENV{DEV_SED_COMPATIBLE}=="DISABLED", GOTO="sedcli_end"
+
+LABEL="check_sedcli_lock"
+ENV{DEV_SED_LOCKED}=="DISABLED", GOTO="sedcli_provision"
+ENV{DEV_SED_LOCKED}=="ENABLED", GOTO="sedcli_unlock"
+
+LABEL="sedcli_provision"
+# Intial provisioning of the device
+RUN+="/usr/sbin/sedcli-kmip -P -d $env{DEVNAME}", GOTO="sedcli_end"
+
+LABEL="sedcli_unlock"
+# Unlock the device
+RUN+="/usr/sbin/sedcli-kmip -L -d $env{DEVNAME} -t RW", GOTO="sedcli_end"
+
+LABEL="sedcli_end"

--- a/src/Makefile
+++ b/src/Makefile
@@ -134,7 +134,7 @@ install-$(TARGET):
 install-$(TARGET)-kmip: install-$(TARGET)
 	@echo " Installing $(TARGET)-kmip"
 	install -m 755 $(TARGET)-kmip /usr/sbin/$(TARGET)-kmip
-	install -m 644 ../lib/udev/rules.d/63-sedcli.rules /usr/lib/udev/rules.d/
+	install -m 644 ../lib/udev/rules.d/63-sedcli.rules /etc/udev/rules.d/
 	install -m 755 -d /etc/sedcli /etc/sedcli/certs
 	install -m 644 ../etc/sedcli/sedcli.conf /etc/sedcli/
 	touch /etc/sedcli/sedcli_kmip && chmod 644 /etc/sedcli/sedcli_kmip
@@ -152,7 +152,7 @@ uninstall:
 	-rm $(LIB_DIR)/$(LIB).so*
 	-rm /usr/share/man/man8/$(TARGET).8
 	-rm /usr/sbin/$(TARGET)-kmip
-	-rm /usr/lib/udev/rules.d/63-sedcli.rules
+	-rm /etc/udev/rules.d/63-sedcli.rules
 	-rm /etc/sedcli/sedcli.conf
 
 uninstall-cert:

--- a/src/Makefile
+++ b/src/Makefile
@@ -134,6 +134,7 @@ install-$(TARGET):
 install-$(TARGET)-kmip: install-$(TARGET)
 	@echo " Installing $(TARGET)-kmip"
 	install -m 755 $(TARGET)-kmip /usr/sbin/$(TARGET)-kmip
+	install -m 644 ../lib/udev/rules.d/63-sedcli.rules /usr/lib/udev/rules.d/
 	install -m 755 -d /etc/sedcli /etc/sedcli/certs
 	install -m 644 ../etc/sedcli/sedcli.conf /etc/sedcli/
 	touch /etc/sedcli/sedcli_kmip && chmod 644 /etc/sedcli/sedcli_kmip
@@ -151,6 +152,7 @@ uninstall:
 	-rm $(LIB_DIR)/$(LIB).so*
 	-rm /usr/share/man/man8/$(TARGET).8
 	-rm /usr/sbin/$(TARGET)-kmip
+	-rm /usr/lib/udev/rules.d/63-sedcli.rules
 	-rm /etc/sedcli/sedcli.conf
 
 uninstall-cert:


### PR DESCRIPTION
This patch adds udev rules to auro-provision and auto-unlock when NVMe
device is added. This can happen for example when OS boots up or new
NVMe disk is hot-inserted into system.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@intel.com>
Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>