### PR TITLE
libsed: nvme_pt: Consider mbr done when enabling/disabling mbr shadow

### DIFF
--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -2086,6 +2086,10 @@ int opal_shadow_mbr_pt(struct sed_device *dev, const struct sed_key *key,
 	if (ret)
 		goto end_sessn;
 
+	ret = opal_set_mbr_done(dev->fd, opal_dev, enable_disable);
+	if (ret)
+		goto end_sessn;
+
 	ret = opal_set_mbr_en_disable(dev->fd, opal_dev, enable_disable);
 
 end_sessn:


### PR DESCRIPTION
Current behavior:
mbr-control enbale=TRUE and done=TRUE => Discover0 MBR Enabled=Y and MBR
Done=Y.
mbr-control enbale=FLASE => Discover0 MBR Enabled=N and MBRDone=Y.
This is a violation of spec.

Actual behavior:
mbr-control enbale=TRUE and done=TRUE => Discover0 MBR Enabled=Y and MBR
Done = Y.
mbr-control enbale=FLASE => Discover0 MBR Enabled=N and MBRDone=N.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>