### PR TITLE
libsed: Make opal level0 discovery struct sed device context

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -159,7 +159,8 @@ int sed_init(struct sed_device **dev, const char *dev_path);
 /**
  *
  */
-int sed_level0_discovery(struct sed_opal_level0_discovery *discv);
+int sed_level0_discovery(struct sed_device *dev,
+			struct sed_opal_level0_discovery *discv);
 
 /**
  *

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -198,42 +198,42 @@ static int get_opal_auth_uid(enum SED_AUTHORITY auth)
 	return sed2opal_map[auth];
 }
 
-static void check_tper_feat(struct sed_opal_level0_discovery *discv,
+static void cpy_tper_feat(struct sed_opal_level0_discovery *discv,
 				void *feat)
 {
 	memcpy(&discv->sed_tper, (struct tper_supported_feat *)feat,
 		sizeof(struct tper_supported_feat));
 }
 
-static void check_locking_feat(struct sed_opal_level0_discovery *discv,
+static void cpy_locking_feat(struct sed_opal_level0_discovery *discv,
 				void *feat)
 {
 	memcpy(&discv->sed_locking, (struct locking_supported_feat *)feat,
 		sizeof(struct locking_supported_feat));
 }
 
-static void check_geometry_feat(struct sed_opal_level0_discovery *discv,
+static void cpy_geometry_feat(struct sed_opal_level0_discovery *discv,
 				void *feat)
 {
 	memcpy(&discv->sed_geo, (struct geometry_supported_feat *)feat,
 		sizeof(struct geometry_supported_feat));
 }
 
-static void check_datastr_feat(struct sed_opal_level0_discovery *discv,
+static void cpy_datastr_feat(struct sed_opal_level0_discovery *discv,
 				void *feat)
 {
 	memcpy(&discv->sed_datastr, (struct datastr_table_supported_feat *)feat,
 		sizeof(struct datastr_table_supported_feat));
 }
 
-static void check_opalv100_feat(struct sed_opal_level0_discovery *discv,
+static void cpy_opalv100_feat(struct sed_opal_level0_discovery *discv,
 				void *feat)
 {
 	memcpy(&discv->sed_opalv100, (struct opalv100_supported_feat *)feat,
 		sizeof(struct opalv100_supported_feat));
 }
 
-static void check_opalv200_feat(struct sed_opal_level0_discovery *discv,
+static void cpy_opalv200_feat(struct sed_opal_level0_discovery *discv,
 				void *feat)
 {
 	memcpy(&discv->sed_opalv200, (struct opalv200_supported_feat *)feat,
@@ -289,28 +289,28 @@ static int opal_level0_disc_pt(struct sed_device *device)
 		case OPAL_FEAT_TPER:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
-			check_tper_feat(discv, &desc->feat.tper.flags);
+			cpy_tper_feat(discv, &desc->feat.tper.flags);
 
 			feat_no++;
 			break;
 		case OPAL_FEAT_LOCKING:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
-			check_locking_feat(discv, &desc->feat.locking.flags);
+			cpy_locking_feat(discv, &desc->feat.locking.flags);
 
 			feat_no++;
 			break;
 		case OPAL_FEAT_GEOMETRY:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
-			check_geometry_feat(discv, &desc->feat.geo);
+			cpy_geometry_feat(discv, &desc->feat.geo);
 
 			feat_no++;
 			break;
 		case OPAL_FEAT_DATASTORE:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
-			check_datastr_feat(discv, &desc->feat.datastr.datastr_tbl);
+			cpy_datastr_feat(discv, &desc->feat.datastr.datastr_tbl);
 
 			feat_no++;
 			break;
@@ -323,14 +323,14 @@ static int opal_level0_disc_pt(struct sed_device *device)
 		case OPAL_FEAT_OPALV100:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
-			check_opalv100_feat(discv, &desc->feat.opalv100);
+			cpy_opalv100_feat(discv, &desc->feat.opalv100);
 
 			feat_no++;
 			break;
 		case OPAL_FEAT_OPALV200:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
-			check_opalv200_feat(discv, &desc->feat.opalv200);
+			cpy_opalv200_feat(discv, &desc->feat.opalv200);
 
 			curr_feat->feat.opalv200.base_comid =
 				be16toh(desc->feat.opalv200.base_comid);

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -355,7 +355,8 @@ struct opal_level0_discovery {
 int opal_init_pt(struct sed_device *dev,
 		const char *device_path);
 
-void opal_level0_discv_info_pt(struct sed_opal_level0_discovery *discvry);
+int opal_level0_discv_info_pt(struct sed_device *dev,
+				struct sed_opal_level0_discovery *discv);
 
 int opal_takeownership_pt(struct sed_device *dev, const struct sed_key *key);
 

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -17,7 +17,7 @@
 #define ARRAY_SIZE(x) ((size_t)(sizeof(x) / sizeof(x[0])))
 
 typedef int (*init)(struct sed_device *, const char *);
-typedef void (*lvl0_discv) (struct sed_opal_level0_discovery *discv);
+typedef int (*lvl0_discv) (struct sed_device *, struct sed_opal_level0_discovery *);
 typedef int (*take_ownership)(struct sed_device *, const struct sed_key *);
 typedef int (*get_msid_pin)(struct sed_device *, struct sed_key *);
 typedef int (*reverttper)(struct sed_device *, const struct sed_key *, bool);
@@ -162,10 +162,11 @@ int sed_init(struct sed_device **dev, const char *dev_path)
 	struct sed_device *ret;
 
 	ret = malloc(sizeof(*ret));
-
 	if (ret == NULL) {
 		return -ENOMEM;
 	}
+
+	memset(ret, 0, sizeof(*ret));
 
 	status = curr_if->init_fn(ret, dev_path);
 	if (status != 0) {
@@ -178,14 +179,13 @@ int sed_init(struct sed_device **dev, const char *dev_path)
 	return status;
 }
 
-int  sed_level0_discovery(struct sed_opal_level0_discovery *discv)
+int sed_level0_discovery(struct sed_device *dev,
+			struct sed_opal_level0_discovery *discv)
 {
 	if (curr_if->lvl0_discv_fn == NULL)
 		return -EOPNOTSUPP;
 
-	curr_if->lvl0_discv_fn(discv);
-
-	return 0;
+	return curr_if->lvl0_discv_fn(dev, discv);
 }
 
 void sed_deinit(struct sed_device *dev)

--- a/src/lib/sed_util.h
+++ b/src/lib/sed_util.h
@@ -18,6 +18,7 @@ enum SED_ACCESSTYPE {
 
 struct sed_device {
 	int fd;
+	struct sed_opal_level0_discovery discv;
 	void *priv;
 };
 

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -516,7 +516,7 @@ static int handle_sed_discv(void)
 {
 	int ret = 0;
 	struct sed_device *dev = NULL;
-	struct sed_opal_level0_discovery *discv = NULL;
+	struct sed_opal_level0_discovery discv = { 0 };
 
 	ret = sed_init(&dev, opts->dev_path);
 	if (ret) {
@@ -524,27 +524,19 @@ static int handle_sed_discv(void)
 		return -EINVAL;
 	}
 
-	discv = malloc(sizeof(*discv));
-	if (discv == NULL) {
-		sedcli_printf(LOG_ERR, "Memory not allocated.\n");
-		ret = -ENOMEM;
-		goto init_deinit;
-	}
-
-	ret = sed_level0_discovery(discv);
+	ret = sed_level0_discovery(dev, &discv);
 	if (ret) {
-		if (ret == -EOPNOTSUPP)
-			sedcli_printf(LOG_ERR, "Command NOT supported for this interface.\n");
+		sedcli_printf(LOG_ERR, "Command NOT supported for this interface.\n");
 		goto deinit;
 	}
 
 	switch(opts->print_fmt) {
 	case SED_NORMAL:
-		sed_discv_print_normal(discv, opts->dev_path);
+		sed_discv_print_normal(&discv, opts->dev_path);
 		ret = 0;
 		break;
 	case SED_UDEV:
-		sed_discv_print_udev(discv);
+		sed_discv_print_udev(&discv);
 		ret = 0;
 		break;
 	default:
@@ -554,8 +546,6 @@ static int handle_sed_discv(void)
 	}
 
 deinit:
-	free(discv);
-init_deinit:
 	sed_deinit(dev);
 
 	return ret;
@@ -761,37 +751,36 @@ static int handle_setpw(void)
 	return ret;
 }
 
-static int check_current_levl0_discv(void)
+static int check_current_levl0_discv(struct sed_device *dev)
 {
-	struct sed_opal_level0_discovery *discv = NULL;
 	int ret;
+	struct sed_opal_level0_discovery discv = { 0 };
 
-	discv = malloc(sizeof(*discv));
-	if (discv == NULL) {
-		sedcli_printf(LOG_ERR, "Memory not allocated.\n");
-		return -ENOMEM;
-	}
-
-	ret = sed_level0_discovery(discv);
+	ret = sed_level0_discovery(dev, &discv);
 	if (ret) {
-		if (ret == -EOPNOTSUPP)
-			sedcli_printf(LOG_ERR, "Command NOT supported for this "
-					"interface.\n");
-		else
-			sedcli_printf(LOG_ERR, "Error in level0 discovery\n");
-		goto free_mem;
+		if (ret == -EOPNOTSUPP) {
+			sedcli_printf(LOG_WARNING, "Level0 discovery not supported "
+					"for this interface.\n");
+			/*
+			 * Continue the operations even if the interface doesn't
+			 * support level0 discovery, the kernel takes care of it
+			 */
+			return 0;
+		} else {
+			sedcli_printf(LOG_ERR, "Error doing level0 discovery\n");
+			return ret;
+		}
 	}
 
 	/*
 	 * Check the current status of any level0 feture (Add them here)
+	 * Return zero on successful checks and -1 on unsuccessful checks
 	 */
-	if (!discv->sed_locking.locking_en) {
+	if (!discv.sed_locking.locking_en) {
 		sedcli_printf(LOG_INFO, "LSP NOT ACTIVATED\n");
 		ret = -1;
 	}
 
-free_mem:
-	free(discv);
 	return ret;
 }
 
@@ -807,8 +796,8 @@ static int handle_mbr_control(void)
 		return ret;
 	}
 
-	ret = check_current_levl0_discv();
-	if (ret != -EOPNOTSUPP && ret != 0)
+	ret = check_current_levl0_discv(dev);
+	if (ret)
 		goto init_deinit;
 
 	sedcli_printf(LOG_INFO, "Enter Admin1 password: ");
@@ -849,8 +838,8 @@ static int handle_write_mbr(void)
 		return ret;
 	}
 
-	ret = check_current_levl0_discv();
-	if (ret != -EOPNOTSUPP && ret != 0)
+	ret = check_current_levl0_discv(dev);
+	if (ret)
 		goto init_deinit;
 
 	mbr_fd = open(opts->file_path, O_RDONLY | O_CLOEXEC);


### PR DESCRIPTION
Make level0 discovery struct sed device context rather than an
individual struct avoiding any over-written conditions.

Move the sed_device struct from sed_util library to libsed library.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>