### PR TITLE
Enable simultaneous use of NVMe-PT and opal-driver

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,11 +28,10 @@ LIB = libsed
 
 LIBOBJS = sed.o
 LIBOBJS += sed_util.o
-ifndef CONFIG_OPAL_DRIVER
 LIBOBJS += nvme_access.o
 LIBOBJS += nvme_pt_ioctl.o
 LIBOBJS += opal_parser.o
-else
+ifdef CONFIG_OPAL_DRIVER
 LIBOBJS += sed_ioctl.o
 endif
 

--- a/src/configure
+++ b/src/configure
@@ -71,7 +71,6 @@ function print_help() {
 	echo "Options:"
 	echo "    --enable-kmip           Doesn't take any effect yet"
 	echo "    --enable-logging        Turns on sedcli debug logging to stdout"
-	echo "    --force-opal-driver     Force compilation of Linux opal driver interface, instead of using NVMe PT"
 }
 
 function print_summary() {
@@ -83,13 +82,10 @@ function print_summary() {
 # Default settings
 kmip_enabled="no"
 sedcli_logging="no"
-force_opal_driver="no"
 
 # Process user specified options
 for option do
 	case "$option" in
-	--force-opal-driver) force_opal_driver="yes"
-	;;
 	--enable-kmip) kmip_enabled="yes"
 	;;
 	--enable-logging) sedcli_logging="yes"
@@ -161,8 +157,8 @@ int main(void)
 }
 EOF
 
-if [ "${force_opal_driver}" == "yes" ] && test_compile "sed interface"; then
-	print_status "SED interface" "opal-driver"
+if test_compile "sed interface"; then
+	print_status "SED interface(s)" "NVMe-PT, opal-driver"
 	app_config_mk "CONFIG_OPAL_DRIVER=y"
 	app_config_h "#define CONFIG_OPAL_DRIVER"
 cat > $TMP_SRC <<EOF
@@ -178,7 +174,7 @@ EOF
 		app_config_h "#define CONFIG_OPAL_DRIVER_PSID_REVERT"
 	fi
 else
-	print_status "SED interface" "NVMe-PT (force-opal-driver=${force_opal_driver})"
+	print_status "SED interface(s)" "NVMe-PT (opal-driver not available)"
 fi
 # ==========================================
 

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -7,6 +7,7 @@
 #include <libsed.h>
 #include <errno.h>
 #include <string.h>
+#include <limits.h>
 #include <linux/version.h>
 
 #include "nvme_pt_ioctl.h"
@@ -15,6 +16,7 @@
 #include "sedcli_log.h"
 
 #define ARRAY_SIZE(x) ((size_t)(sizeof(x) / sizeof(x[0])))
+#define NVME_DEV_PREFIX "nvme"
 
 typedef int (*init)(struct sed_device *, const char *);
 typedef int (*lvl0_discv) (struct sed_device *, struct sed_opal_level0_discovery *);
@@ -72,7 +74,6 @@ struct opal_interface {
 	deinit deinit_fn;
 };
 
-
 #ifdef CONFIG_OPAL_DRIVER
 static struct opal_interface opal_if = {
 	.init_fn = sedopal_init,
@@ -98,9 +99,9 @@ static struct opal_interface opal_if = {
 	.list_lr_fn = NULL,
 	.deinit_fn = sedopal_deinit
 };
+#endif
 
-#else
-static struct opal_interface opal_if = {
+static struct opal_interface nvmept_if = {
 	.init_fn	= opal_init_pt,
 	.lvl0_discv_fn	= opal_level0_discv_info_pt,
 	.ownership_fn	= opal_takeownership_pt,
@@ -124,9 +125,8 @@ static struct opal_interface opal_if = {
 	.list_lr_fn	= opal_list_lr_pt,
 	.deinit_fn	= opal_deinit_pt
 };
-#endif
 
-static struct opal_interface *curr_if = &opal_if;
+static struct opal_interface *curr_if = &nvmept_if;
 
 struct sed_status_ret {
 	int code;
@@ -160,6 +160,7 @@ int sed_init(struct sed_device **dev, const char *dev_path)
 {
 	int status = 0;
 	struct sed_device *ret;
+	char *base;
 
 	ret = malloc(sizeof(*ret));
 	if (ret == NULL) {
@@ -167,6 +168,16 @@ int sed_init(struct sed_device **dev, const char *dev_path)
 	}
 
 	memset(ret, 0, sizeof(*ret));
+
+	base = basename(dev_path);
+	if (strncmp(base, NVME_DEV_PREFIX, strnlen(NVME_DEV_PREFIX, PATH_MAX))) {
+#ifdef CONFIG_OPAL_DRIVER
+		curr_if = &opal_if;
+#else
+		SEDCLI_DEBUG_PARAM("%s is not an NVMe device and opal-driver not built-in!\n", dev_path);
+		return -EINVAL;
+#endif
+	}
 
 	status = curr_if->init_fn(ret, dev_path);
 	if (status != 0) {

--- a/src/lib/sed_util.c
+++ b/src/lib/sed_util.c
@@ -14,24 +14,14 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <unistd.h>
-#include <limits.h>
 
 #include "sed_util.h"
 #include "sedcli_log.h"
-
-#define NVME_DEV_PREFIX "nvme"
 
 int open_dev(const char *dev)
 {
 	int err, fd;
 	struct stat _stat;
-	char *base;
-
-	base = basename(dev);
-	if (strncmp(base, NVME_DEV_PREFIX, strnlen(NVME_DEV_PREFIX, PATH_MAX))) {
-		SEDCLI_DEBUG_PARAM("%s is not an NVMe device!\n", dev);
-		return -EINVAL;
-	}
 
 	err = open(dev, O_RDONLY);
 	if (err < 0)


### PR DESCRIPTION
Make CONFIG_OPAL_DRIVER driver selection no longer exclusive:
use it as a toggle for enabling the opal-driver in addition to
the NVMe-PT driver.

Remove --force-opal-driver configure flag, but preserve
CONFIG_OPAL_DRIVER enablement conditional based on opal driver
test_compile.

Move nvme* block device prefix check from lib/sed_util.c to
lib/sed.c and use it as the basis for dynamically choosing either
the NVMe-PT or opal-driver interface before an interface-specific
init call.

Signed-off-by: Kenneth J. Miller <ken@miller.ec>
_________________________________________________________________________

This PR allows a single compiled binary to use both the NVMe-PT and opal-driver interface, when previously the --force-opal-driver configure flag would enable either only the opal-driver or the NVMe-PT interface.

Personally I have the use case where I have NVMes and SATA drives on the same host and want to use sedcli functionality for both.

I've run a basic functional test against my local host which is equipped with both Samsung SSD 970 EVO NVMes and Samsung SSD 860 EVO SATA drives, and I can confirm the change works for both the NVMe-PT and opal-driver interfaces on these drives, respectively.