### PR TITLE
libsed, sedcli: enable printing out BlockSID from level0 discovery

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -106,13 +106,28 @@ struct sed_tper_properties {
 	} property[NUM_TPER_PROPS];
 } __attribute__((__packed__));
 
+struct sed_blocksid_supported_feat {
+	uint8_t sid_valuestate:1;
+	uint8_t sid_blockstate:1;
+	uint8_t reserved1:6;
+	uint8_t hardware_reset:1;
+	uint8_t reserved2:7;
+	uint8_t reserved3[10];
+} __attribute__((__packed__));
+
 struct sed_opal_level0_discovery {
+	struct {
+		uint64_t feat_blocksid:1;
+		uint64_t reserved:63;
+	} __attribute__((__packed__)) feat_avail_flag;
+
 	struct sed_tper_supported_feat sed_tper;
 	struct sed_locking_supported_feat sed_locking;
 	struct sed_geometry_supported_feat sed_geo;
 	struct sed_datastr_table_supported_feat sed_datastr;
 	struct sed_opalv100_supported_feat sed_opalv100;
 	struct sed_opalv200_supported_feat sed_opalv200;
+	struct sed_blocksid_supported_feat sed_blocksid;
 };
 
 struct sed_opal_device_discv {

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -30,6 +30,7 @@
 #define OPAL_FEAT_SUM        0x0201
 #define OPAL_FEAT_OPALV100   0x0200
 #define OPAL_FEAT_OPALV200   0x0203
+#define OPAL_FEAT_BLOCKSID   0x0402
 
 #define SUM_SELECTION_LIST   0x060000
 
@@ -242,6 +243,13 @@ static void cpy_opalv100_feat(struct sed_opal_level0_discovery *discv,
 		sizeof(struct opalv100_supported_feat));
 }
 
+static void cpy_blocksid_feat(struct sed_opal_level0_discovery *discv,
+				void *feat)
+{
+	memcpy(&discv->sed_blocksid, (struct blocksid_supported_feat *)feat,
+		sizeof(struct blocksid_supported_feat));
+}
+
 static void cpy_opalv200_feat(struct sed_opal_level0_discovery *discv,
 				void *feat)
 {
@@ -326,6 +334,14 @@ static int opal_level0_disc_pt(struct sed_device *device)
 		case OPAL_FEAT_SUM:
 			curr_feat = &disc_data->feats[feat_no];
 			curr_feat->type = feat_code;
+
+			feat_no++;
+			break;
+		case OPAL_FEAT_BLOCKSID:
+			curr_feat = &disc_data->feats[feat_no];
+			curr_feat->type = feat_code;
+			cpy_blocksid_feat(discv, &desc->feat.blocksid);
+			discv->feat_avail_flag.feat_blocksid = 1;
 
 			feat_no++;
 			break;

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -227,6 +227,15 @@ struct datastr_table_supported_feat {
 	uint32_t datastr_tbl_size_align;
 } __attribute__((__packed__));
 
+struct blocksid_supported_feat {
+	uint8_t sid_valuestate:1;
+	uint8_t sid_blockedstate:1;
+	uint8_t reserved:6;
+	uint8_t hardware_reset:1;
+	uint8_t reserved1:7;
+	uint8_t reserved2[10];
+} __attribute__((__packed__));
+
 struct opalv100_supported_feat {
 	uint16_t v1_base_comid;
 	uint16_t v1_comid_num;
@@ -307,6 +316,8 @@ struct opal_level0_feat_desc {
 		struct opalv100_supported_feat opalv100;
 
 		struct opalv200_supported_feat opalv200;
+
+		struct blocksid_supported_feat blocksid;
 	} feat;
 } __attribute__((__packed__)) ;
 

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -493,6 +493,19 @@ static void sed_discv_print_normal(struct sed_opal_device_discv *discv, const ch
 			      discv->sed_tper_props.property[i].value);
 	}
 
+	if (discv->sed_lvl0_discv.feat_avail_flag.feat_blocksid) {
+		/* Printing BlockSID Features */
+		sedcli_printf(LOG_INFO, "\nBlock SID FEATURES SUPPORTED\n");
+		sedcli_printf(LOG_INFO, "\tSID Value State                   : %d\n",
+						discv->sed_lvl0_discv.sed_blocksid.sid_valuestate ? 1 : 0);
+
+		sedcli_printf(LOG_INFO, "\tSID Blocked State                 : %d\n",
+						discv->sed_lvl0_discv.sed_blocksid.sid_blockstate ? 1 : 0);
+
+		sedcli_printf(LOG_INFO, "\tHardware Reset Flag               : %d\n",
+						discv->sed_lvl0_discv.sed_blocksid.hardware_reset ? 1 : 0);
+	}
+
 	sedcli_printf(LOG_INFO, "\n");
 }
 


### PR DESCRIPTION
This patch enables the support of BlockSID Level0 discovery feature
table 0x402 in sedcli so sedcli -D can include SSD BlockSID state.

Signed-off-by: Winson Yung <winson.yung@intel.com>