### PR TITLE
libsed,sedcli: Introduced non-destructive revert operation.

### DIFF
--- a/doc/sedcli.8
+++ b/doc/sedcli.8
@@ -60,8 +60,9 @@ Takes ownership of the device.
 .IP "\fB\-A -d <device>\fR or \fB\-\-activate-lsp --device <device>\fR"
 Activates Locking SP.
 
-.IP "\fB\-R -d <device> [-i]\fR or \fB\-\-revert --device <device> [--psid]\fR"
-Reverts TPer to Manufactured-Inactivate state using either SID or PSID authority.
+.IP "\fB\-R -d <device> [-i] [-n]\fR or \fB\-\-revert --device <device> [--psid] [--non-destructive]\fR"
+Performs Destructive or Non-Destructive Revert TPer to Manufactured-Inactivate
+state using either SID or PSID authority.
 
 .IP "\fB\-S -d <device>\fR or \fB\-\-setup-global-range --device <device>\fR"
 Sets Read Lock Enabled (RLE) and Write Lock Enabled (WLE) bis for global locking

--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -200,7 +200,7 @@ int sed_lock_unlock(struct sed_device *dev, const struct sed_key *key, enum SED_
 /**
  *
  */
-int sed_reverttper(struct sed_device *dev, const struct sed_key *key, bool psid);
+int sed_reverttper(struct sed_device *dev, const struct sed_key *key, bool psid, bool non_destructive);
 
 /**
  * Revert Locking SP to its Original Factory State.

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -1767,14 +1767,25 @@ end_sessn:
 }
 
 int opal_reverttper_pt(struct sed_device *dev, const struct sed_key *key,
-		bool psid)
+		bool psid, bool non_destructive)
 {
 	struct opal_device *opal_dev;
 	int ret = 0, auth;
 
-	if (key == NULL) {
-		SEDCLI_DEBUG_MSG("Must Provide a password.\n");
+	if (psid && non_destructive) {
+		SEDCLI_DEBUG_MSG("non_destructive cannot be performed when psid is selected.\n");
 		return -EINVAL;
+	}
+
+	if (dev == NULL || key == NULL) {
+		SEDCLI_DEBUG_MSG("Must provide a password or a valid device\n");
+		return -EINVAL;
+	}
+
+	if (non_destructive) {
+		ret = opal_revertlsp_pt(dev, key, true);
+		if (ret)
+			return ret;
 	}
 
 	opal_dev = dev->priv;
@@ -2282,7 +2293,6 @@ int opal_list_lr_pt(struct sed_device *dev, const struct sed_key *key,
 		goto end_sessn;
 
 	ret = list_lr(dev->fd, opal_dev, lrs);
-
 end_sessn:
 	opal_end_session(dev->fd, opal_dev);
 	return ret;

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -362,7 +362,8 @@ int opal_takeownership_pt(struct sed_device *dev, const struct sed_key *key);
 
 int opal_get_msid_pin_pt(struct sed_device *dev, struct sed_key *msid_pin);
 
-int opal_reverttper_pt(struct sed_device *dev, const struct sed_key *key, bool psid);
+int opal_reverttper_pt(struct sed_device *dev, const struct sed_key *key, bool psid,
+		       bool non_destructive);
 
 int opal_revertlsp_pt(struct sed_device *dev, const struct sed_key *key,
 		bool keep_global_rn_key);

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -20,7 +20,7 @@ typedef int (*init)(struct sed_device *, const char *);
 typedef int (*lvl0_discv) (struct sed_device *, struct sed_opal_level0_discovery *);
 typedef int (*take_ownership)(struct sed_device *, const struct sed_key *);
 typedef int (*get_msid_pin)(struct sed_device *, struct sed_key *);
-typedef int (*reverttper)(struct sed_device *, const struct sed_key *, bool);
+typedef int (*reverttper)(struct sed_device *, const struct sed_key *, bool, bool);
 typedef int (*activate_lsp)(struct sed_device *, const struct sed_key *,
 			char *, bool);
 typedef int (*revertsp)(struct sed_device *, const struct sed_key *, bool);
@@ -236,9 +236,9 @@ int sed_setup_global_range(struct sed_device *dev, const struct sed_key *key)
 	return curr_if->setup_global_range_fn(dev, key);
 }
 
-int sed_reverttper(struct sed_device *dev, const struct sed_key *key, bool psid)
+int sed_reverttper(struct sed_device *dev, const struct sed_key *key, bool psid, bool non_destructive)
 {
-	return curr_if->revert_fn(dev, key, psid);
+	return curr_if->revert_fn(dev, key, psid, non_destructive);
 }
 
 int sed_revertlsp(struct sed_device *dev, const struct sed_key *key, bool keep_global_rn_key)

--- a/src/lib/sed_ioctl.c
+++ b/src/lib/sed_ioctl.c
@@ -377,10 +377,13 @@ int sedopal_secure_erase_lr(struct sed_device *dev, const char *password, uint8_
 }
 
 int sedopal_reverttper(struct sed_device *dev, const struct sed_key *key,
-				bool psid)
+				bool psid, bool non_destructive)
 {
 	int fd = dev->fd;
 	unsigned long ioctl_code;
+
+	if (non_destructive)
+		return -EOPNOTSUPP;
 
 	if (psid) {
 #ifdef CONFIG_OPAL_DRIVER_PSID_REVERT

--- a/src/lib/sed_ioctl.h
+++ b/src/lib/sed_ioctl.h
@@ -47,7 +47,7 @@ int sedopal_erase_lr(struct sed_device *dev, const char *password,
 int sedopal_secure_erase_lr(struct sed_device *dev, const char *password,
 		uint8_t key_len, const char *user, uint8_t lr, bool sum);
 
-int sedopal_reverttper(struct sed_device *dev, const struct sed_key *key, bool psid);
+int sedopal_reverttper(struct sed_device *dev, const struct sed_key *key, bool psid, bool non_destructive);
 
 int sedopal_save(struct sed_device *dev, const char *password, uint8_t key_len,
 				const char *user, enum SED_ACCESS_TYPE lock_type, uint8_t lr, bool sum);

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -67,7 +67,7 @@ static cli_option activatelsp_opts[] = {
 static cli_option reverttper_opts[] = {
 	{'d', "device", "Device node e.g. /dev/nvme0n1", 1, "DEVICE", CLI_OPTION_REQUIRED},
 	{'i', "psid", "Revert Trusted Peripheral (TPer) with the PSID authority", 0, "FLAG", CLI_OPTION_OPTIONAL_ARG},
-	{'n', "non-destructive", "Non-Destructive Revert Trusted Peripheral (TPer) with the PSID authority", 0, "FLAG", CLI_OPTION_OPTIONAL_ARG},
+	{'n', "non-destructive", "Perform non-destructive revert on TPer (i.e. keep the user data intact even after revert)", 0, "FLAG", CLI_OPTION_OPTIONAL_ARG},
 	{0}
 };
 

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -67,6 +67,7 @@ static cli_option activatelsp_opts[] = {
 static cli_option reverttper_opts[] = {
 	{'d', "device", "Device node e.g. /dev/nvme0n1", 1, "DEVICE", CLI_OPTION_REQUIRED},
 	{'i', "psid", "Revert Trusted Peripheral (TPer) with the PSID authority", 0, "FLAG", CLI_OPTION_OPTIONAL_ARG},
+	{'n', "non-destructive", "Non-Destructive Revert Trusted Peripheral (TPer) with the PSID authority", 0, "FLAG", CLI_OPTION_OPTIONAL_ARG},
 	{0}
 };
 
@@ -238,6 +239,7 @@ struct sedcli_options {
 	int enable;
 	int done;
 	int offset;
+	int non_destructive;
 };
 
 static struct sedcli_options *opts = NULL;
@@ -300,6 +302,8 @@ int reverttper_handle_opts(char *opt, char **arg)
 		strncpy(opts->dev_path, arg[0], PATH_MAX - 1);
 	} else if (!strcmp(opt, "psid")) {
 		opts->psid = 1;
+	} else if (!strcmp(opt, "non-destructive")) {
+		opts->non_destructive = 1;
 	}
 
 	return 0;
@@ -637,7 +641,7 @@ static int handle_reverttper(void)
 		return ret;
 	}
 
-	ret = sed_reverttper(dev, &opts->pwd, opts->psid);
+	ret = sed_reverttper(dev, &opts->pwd, opts->psid, opts->non_destructive);
 
 	print_sed_status(ret);
 


### PR DESCRIPTION
This patch introduces a non-destructive revert operation. This can be
performed with -n option when running the revert command.

Signed-off-by: Kevin OLinn <kevin.olinn@intel.com>