### PR TITLE
libsed, sedcli: enable blockSID functionality per TCG BlockSID spec

### DIFF
--- a/doc/sedcli.8
+++ b/doc/sedcli.8
@@ -91,6 +91,9 @@ MBR Done update to TRUE will only take effect when MBR Shadow is enabled.
 Write data into MBR shadow region(MBR table).
 MBR shadow should be enabled for the PBA to take effect.
 
+.IP "\fB\-B -d <device>\fR or \fB\-\-block_sid --device <device> --hwreset {1|0}\fR"
+Issue BlockSID authentication command with Clear Event flag via --hwreset option.
+
 .IP "\fB\-V\fR or \fB\-\-version\fR"
 Prints version of sedcli.
 

--- a/doc/sedcli.8
+++ b/doc/sedcli.8
@@ -91,7 +91,7 @@ MBR Done update to TRUE will only take effect when MBR Shadow is enabled.
 Write data into MBR shadow region(MBR table).
 MBR shadow should be enabled for the PBA to take effect.
 
-.IP "\fB\-B -d <device>\fR or \fB\-\-block_sid --device <device> --hwreset {1|0}\fR"
+.IP "\fB\-B -d <device> -r {1|0}\fR or \fB\-\-block_sid --device <device> --hwreset {1|0}\fR"
 Issue BlockSID authentication command with Clear Event flag via --hwreset option.
 
 .IP "\fB\-V\fR or \fB\-\-version\fR"

--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -321,6 +321,12 @@ int sed_mbrdone(struct sed_device *dev, const struct sed_key *key, bool mbr);
 int sed_write_shadow_mbr(struct sed_device *dev, const struct sed_key *key,
 			  const uint8_t *from, uint32_t size, uint32_t offset);
 
+
+/**
+ *
+ */
+int sed_issue_blocksid_cmd(struct sed_device *dev, bool hw_reset);
+
 /**
  *
  */

--- a/src/lib/nvme_access.c
+++ b/src/lib/nvme_access.c
@@ -44,11 +44,11 @@ static int send_recv_nvme_pt_ioctl(int fd, int send, uint8_t proto_id,
 	return status;
 }
 
-static int opal_send(int fd, uint16_t com_id, uint8_t *buf, int buf_len)
+int opal_send(int fd, uint8_t proto_id, uint16_t com_id, uint8_t *buf, int buf_len)
 {
 	int ret;
 
-	ret = send_recv_nvme_pt_ioctl(fd, SEND, TCG_SECP_01, com_id, buf,
+	ret = send_recv_nvme_pt_ioctl(fd, SEND, proto_id, com_id, buf,
 			buf_len);
 
 	return ret;
@@ -89,7 +89,7 @@ int opal_send_recv(int fd, uint16_t com_id, uint8_t *req_buf,
 {
 	int ret;
 
-	ret = opal_send(fd, com_id, req_buf, req_buf_len);
+	ret = opal_send(fd, TCG_SECP_01, com_id, req_buf, req_buf_len);
 	if (ret)
 		return ret;
 

--- a/src/lib/nvme_access.h
+++ b/src/lib/nvme_access.h
@@ -12,6 +12,7 @@
 int opal_send_recv(int fd, uint16_t com_id, uint8_t *req_buf,
 		int req_buf_len, uint8_t *resp_buf, int resp_buf_len);
 
+int opal_send(int fd, uint8_t proto_id, uint16_t com_id, uint8_t *buf, int buf_len);
 int opal_recv(int fd, uint16_t com_id, uint8_t *buf, int buf_len);
 
 #endif /* _NVME_ACCESS_H_ */

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -40,6 +40,9 @@
 
 #define MIN_IO_BUFFER_LEN 2048
 
+#define OPAL_BLOCKSID_COMID  5
+#define BLOCKSID_PAYLOAD_SZ  512
+
 /* #define TPer property name strings here */
 #define MCPS "MaxComPacketSize"
 
@@ -2494,6 +2497,32 @@ int opal_write_shadow_mbr_pt(struct sed_device *dev, const struct sed_key *key,
 
 end_sessn:
 	opal_end_session(dev->fd, opal_dev);
+	return ret;
+}
+
+int opal_block_sid_pt(struct sed_device *dev, bool hw_reset)
+{
+	struct opal_device *device = dev->priv;
+	int ret, req_size = BLOCKSID_PAYLOAD_SZ;
+
+	/* Send Block SID authentication command, no IF_RECV response is expected */
+
+	if (device->req_buf_size < BLOCKSID_PAYLOAD_SZ) {
+		SEDCLI_DEBUG_MSG("Too small buffer size of BlockSID payload\n");
+		return -EINVAL;
+	}
+
+	/* Set Hardware Reset in LSB of the first byte in  */
+	/* BlockSID payload based on Clear Event flag user */
+	/* supplied through hwreset argument               */
+	*(device->req_buf) = hw_reset ? 1 : 0;
+
+	ret = opal_send(dev->fd, TCG_SECP_02, OPAL_BLOCKSID_COMID,
+							device->req_buf, req_size);
+	if (ret) {
+		SEDCLI_DEBUG_MSG("Error in NVMe passthrough ops\n");
+	}
+
 	return ret;
 }
 

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -2505,10 +2505,10 @@ int opal_block_sid_pt(struct sed_device *dev, bool hw_reset)
 	struct opal_device *device = dev->priv;
 	int ret;
 
-	/* Send Block SID authentication command, no IF_RECV response is expected */
-
-	/* Set Hardware Reset in LSB of the first byte in
-	 * BlockSID payload based on Clear Event flag user
+	/* Send Block SID authentication command, no
+	 * IF_RECV response is expected. Set Hardware
+	 * Reset in LSB of the first byte in BlockSID
+	 * payload based on Clear Event flag user
 	 * supplied through hwreset argument */
 
 	*(device->req_buf) = hw_reset ? 1 : 0;

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -2503,22 +2503,18 @@ end_sessn:
 int opal_block_sid_pt(struct sed_device *dev, bool hw_reset)
 {
 	struct opal_device *device = dev->priv;
-	int ret, req_size = BLOCKSID_PAYLOAD_SZ;
+	int ret;
 
 	/* Send Block SID authentication command, no IF_RECV response is expected */
 
-	if (device->req_buf_size < BLOCKSID_PAYLOAD_SZ) {
-		SEDCLI_DEBUG_MSG("Too small buffer size of BlockSID payload\n");
-		return -EINVAL;
-	}
+	/* Set Hardware Reset in LSB of the first byte in
+	 * BlockSID payload based on Clear Event flag user
+	 * supplied through hwreset argument */
 
-	/* Set Hardware Reset in LSB of the first byte in  */
-	/* BlockSID payload based on Clear Event flag user */
-	/* supplied through hwreset argument               */
 	*(device->req_buf) = hw_reset ? 1 : 0;
 
 	ret = opal_send(dev->fd, TCG_SECP_02, OPAL_BLOCKSID_COMID,
-							device->req_buf, req_size);
+							device->req_buf, BLOCKSID_PAYLOAD_SZ);
 	if (ret) {
 		SEDCLI_DEBUG_MSG("Error in NVMe passthrough ops\n");
 	}

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -75,6 +75,7 @@
 enum {
 	TCG_SECP_00 = 0,
 	TCG_SECP_01,
+	TCG_SECP_02,
 };
 
 enum opaluid {
@@ -438,6 +439,8 @@ int opal_ds_add_anybody_get(struct sed_device *dev, const struct sed_key *key);
 
 int opal_list_lr_pt(struct sed_device *dev, const struct sed_key *key,
 		    struct sed_opal_lockingranges *lrs);
+
+int opal_block_sid_pt(struct sed_device *dev, bool hw_reset);
 
 void opal_deinit_pt(struct sed_device *dev);
 

--- a/src/lib/sed.c
+++ b/src/lib/sed.c
@@ -47,6 +47,7 @@ typedef int (*ds_read)(struct sed_device *, enum SED_AUTHORITY, const struct sed
 typedef int (*ds_write)(struct sed_device *, enum SED_AUTHORITY, const struct sed_key *, const uint8_t *, uint32_t, uint32_t);
 typedef int (*list_lr)(struct sed_device *, const struct sed_key *,
 		       struct sed_opal_lockingranges *);
+typedef int (*blocksid)(struct sed_device *, bool);
 typedef void (*deinit)(struct sed_device *);
 
 struct opal_interface {
@@ -71,6 +72,7 @@ struct opal_interface {
 	ds_read ds_read_fn;
 	ds_write ds_write_fn;
 	list_lr list_lr_fn;
+	blocksid blocksid_fn;
 	deinit deinit_fn;
 };
 
@@ -97,6 +99,7 @@ static struct opal_interface opal_if = {
 	.ds_read_fn = NULL,
 	.ds_write_fn = NULL,
 	.list_lr_fn = NULL,
+	.blocksid_fn = NULL,
 	.deinit_fn = sedopal_deinit
 };
 #endif
@@ -123,6 +126,7 @@ static struct opal_interface nvmept_if = {
 	.ds_read_fn = opal_ds_read,
 	.ds_write_fn = opal_ds_write,
 	.list_lr_fn	= opal_list_lr_pt,
+	.blocksid_fn	= opal_block_sid_pt,
 	.deinit_fn	= opal_deinit_pt
 };
 
@@ -367,6 +371,14 @@ int sed_list_lr(struct sed_device *dev, const struct sed_key *key,
 		return -EOPNOTSUPP;
 
 	return curr_if->list_lr_fn(dev, key, lrs);
+}
+
+int sed_issue_blocksid_cmd(struct sed_device *dev, bool hw_reset)
+{
+	if (curr_if->blocksid_fn == NULL)
+		return -EOPNOTSUPP;
+
+	return curr_if->blocksid_fn(dev, hw_reset);
 }
 
 const char *sed_error_text(int sed_status)

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -105,7 +105,7 @@ static cli_option write_mbr_opts[] = {
 
 static cli_option blocksid_opts[] = {
 	{'d', "device", "Device node e.g. /dev/nvme0n1", 1, "DEVICE", CLI_OPTION_REQUIRED},
-	{'r', "hwreset", "Clear events by setting Hardware Reset flag. Allowed values: 1/0", 1, "FMT", CLI_OPTION_RANGE_INT, 0, 1, 0},
+	{'r', "hwreset", "Clear events by setting Hardware Reset flag. Allowed values: 1/0", 1, "FMT", CLI_OPTION_REQUIRED},
 	{0}
 };
 
@@ -431,7 +431,10 @@ int blocksid_handle_opts(char *opt, char **arg)
 
 	if (!strcmp(opt, "device")) {
 		strncpy(opts->dev_path, arg[0], PATH_MAX - 1);
-	} else if (!strcmp(opt, "hwreset")) {
+	} else if (!strcmp(opt, "hwreset") && strlen(arg[0]) == 1) {
+		if ((arg[0][0] != '0') && (arg[0][0] != '1')) {
+			return -EINVAL;
+		}
 		hwreset_flag = atoi(arg[0]);
 		opts->hardware_reset = (hwreset_flag == 1) ? true : false;
 	}

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -35,6 +35,7 @@ static int setup_global_range_handle_opts(char *opt, char **arg);
 static int setpw_handle_opts(char *opt, char **arg);
 static int mbr_control_handle_opts(char *opt, char **arg);
 static int write_mbr_handle_opts(char *opt, char **arg);
+static int blocksid_handle_opts(char *opt, char **arg);
 
 static int handle_sed_discv(void);
 static int handle_ownership(void);
@@ -47,6 +48,7 @@ static int handle_setup_global_range(void);
 static int handle_setpw(void);
 static int handle_mbr_control(void);
 static int handle_write_mbr(void);
+static int handle_blocksid(void);
 
 static cli_option sed_discv_opts[] = {
 	{'d', "device", "Device node e.g. /dev/nvme0n1", 1, "DEVICE", CLI_OPTION_REQUIRED},
@@ -98,6 +100,12 @@ static cli_option write_mbr_opts[] = {
 	{'d', "device", "Device node e.g. /dev/nvme0n1", 1, "DEVICE", CLI_OPTION_REQUIRED},
 	{'f', "file", "File path containing Pre-boot Application(PBA) image ", 1, "FMT", CLI_OPTION_REQUIRED},
 	{'o', "offset", "Enter the offset(by default 0)", 1, "NUM", CLI_OPTION_OPTIONAL_ARG},
+	{0}
+};
+
+static cli_option blocksid_opts[] = {
+	{'d', "device", "Device node e.g. /dev/nvme0n1", 1, "DEVICE", CLI_OPTION_REQUIRED},
+	{'r', "hwreset", "Clear events by setting Hardware Reset flag. Allowed values: 1/0", 1, "FMT", CLI_OPTION_REQUIRED},
 	{0}
 };
 
@@ -203,6 +211,17 @@ static cli_command sedcli_commands[] = {
 		.help = NULL
 	},
 	{
+		.name = "block_sid",
+		.short_name = 'B',
+		.desc = "Issue BlockSID authentication command",
+		.long_desc = "Issue BlockSID authentication command",
+		.options = blocksid_opts,
+		.command_handle_opts = blocksid_handle_opts,
+		.handle = handle_blocksid,
+		.flags = 0,
+		.help = NULL
+	},
+	{
 		.name = "version",
 		.short_name = 'V',
 		.desc = "Print sedcli version",
@@ -239,6 +258,7 @@ struct sedcli_options {
 	int enable;
 	int done;
 	int offset;
+	bool hardware_reset;
 	int non_destructive;
 };
 
@@ -399,6 +419,20 @@ int write_mbr_handle_opts(char *opt, char **arg)
 			return -EINVAL;
 		}
 		offset_flag = true;
+	}
+
+	return 0;
+}
+
+int blocksid_handle_opts(char *opt, char **arg)
+{
+	int hwreset_flag = 0; /* No reset BlockSID upon power events */
+
+	if (!strcmp(opt, "device")) {
+		strncpy(opts->dev_path, arg[0], PATH_MAX - 1);
+	} else if (!strcmp(opt, "hwreset")) {
+		hwreset_flag = atoi(arg[0]);
+		opts->hardware_reset = (hwreset_flag == 1) ? true : false;
 	}
 
 	return 0;
@@ -971,6 +1005,25 @@ close_fd:
 	close(mbr_fd);
 init_deinit:
 	sed_deinit(dev);
+	return ret;
+}
+
+static int handle_blocksid(void)
+{
+	struct sed_device *dev = NULL;
+	int ret = sed_init(&dev, opts->dev_path);
+
+	if (ret) {
+		sedcli_printf(LOG_ERR, "Error in initializing the dev: %s\n",
+				opts->dev_path);
+		return ret;
+	}
+
+	ret = sed_issue_blocksid_cmd(dev, opts->hardware_reset);
+
+	print_sed_status(ret);
+	sed_deinit(dev);
+
 	return ret;
 }
 

--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -105,7 +105,7 @@ static cli_option write_mbr_opts[] = {
 
 static cli_option blocksid_opts[] = {
 	{'d', "device", "Device node e.g. /dev/nvme0n1", 1, "DEVICE", CLI_OPTION_REQUIRED},
-	{'r', "hwreset", "Clear events by setting Hardware Reset flag. Allowed values: 1/0", 1, "FMT", CLI_OPTION_REQUIRED},
+	{'r', "hwreset", "Clear events by setting Hardware Reset flag. Allowed values: 1/0", 1, "FMT", CLI_OPTION_RANGE_INT, 0, 1, 0},
 	{0}
 };
 
@@ -426,7 +426,8 @@ int write_mbr_handle_opts(char *opt, char **arg)
 
 int blocksid_handle_opts(char *opt, char **arg)
 {
-	int hwreset_flag = 0; /* No reset BlockSID upon power events */
+	/* No reset BlockSID upon power events */
+	int hwreset_flag = 0;
 
 	if (!strcmp(opt, "device")) {
 		strncpy(opts->dev_path, arg[0], PATH_MAX - 1);


### PR DESCRIPTION
This patch enables the support of BlockSID to block SID authority.
The feature supports using Clear Event flag that can determine the
blocking can be reset by SSD firmware during hardware reset.

Signed-off-by: Winson Yung <winson.yung@intel.com>