### PR TITLE
libsed, sedcli: add processing and display of Pyrite v1.00 and v2.00

### DIFF
--- a/src/lib/include/libsed.h
+++ b/src/lib/include/libsed.h
@@ -99,6 +99,30 @@ struct sed_opalv200_supported_feat {
 	uint8_t reserved2[5];
 } __attribute__((__packed__));
 
+struct sed_pyrite_supported_feat {
+	uint16_t base_comid;
+	uint16_t comid_num;
+	uint8_t reserved[5];
+	uint8_t init_pin;
+	uint8_t revert_pin;
+	uint8_t reserved2[5];
+} __attribute__((__packed__));
+
+struct sed_data_rm_mechanism_feat {
+	uint8_t reserved;
+	struct {
+		uint8_t rm_op_processing:1;
+		uint8_t rsvd1:7;
+	} __attribute__((__packed__)) rmopprocessing_rsvd;
+	uint8_t supp_data_rm_mechanism;
+	struct {
+		uint8_t data_rm_time_fmt:6;
+		uint8_t rsvd2:2;
+	} __attribute__((__packed__)) datarmtimefmtbits_rsvd;
+	uint16_t data_rm_time[6];
+	uint8_t reserved2[16];
+} __attribute__((__packed__));
+
 struct sed_tper_properties {
 	struct {
 		char key_name[MAX_PROP_NAME_LEN];
@@ -136,10 +160,13 @@ struct sed_opal_level0_discovery {
 		uint64_t feat_opalv100:1;
 		uint64_t feat_opalv200:1;
 		uint64_t feat_ruby:1;
+		uint64_t feat_pyritev100:1;
+		uint64_t feat_pyritev200:1;
+		uint64_t feat_data_rm_mechanism:1;
 		uint64_t feat_blocksid:1;
 		uint64_t feat_sum:1;
 		uint64_t feat_cnl:1;
-		uint64_t reserved:54;
+		uint64_t reserved:51;
 	} __attribute__((__packed__)) feat_avail_flag;
 
 	struct sed_tper_supported_feat sed_tper;
@@ -149,6 +176,9 @@ struct sed_opal_level0_discovery {
 	struct sed_opalv100_supported_feat sed_opalv100;
 	struct sed_opalv200_supported_feat sed_opalv200;
 	struct sed_opalv200_supported_feat sed_ruby;
+	struct sed_pyrite_supported_feat sed_pyritev100;
+	struct sed_pyrite_supported_feat sed_pyritev200;
+	struct sed_data_rm_mechanism_feat sed_data_rm_mechanism;
 	struct sed_blocksid_supported_feat sed_blocksid;
 	struct sed_cnl_feat sed_cnl;
 };

--- a/src/lib/nvme_pt_ioctl.c
+++ b/src/lib/nvme_pt_ioctl.c
@@ -30,9 +30,12 @@
 #define OPAL_FEAT_SUM        0x0201
 #define OPAL_FEAT_OPALV100   0x0200
 #define OPAL_FEAT_OPALV200   0x0203
+#define OPAL_FEAT_PYRITEV100 0x0302
+#define OPAL_FEAT_PYRITEV200 0x0303
 #define OPAL_FEAT_RUBY       0x0304
 #define OPAL_FEAT_BLOCKSID   0x0402
 #define OPAL_FEAT_CNL        0x0403
+#define OPAL_FEAT_DATA_RM    0x0404
 
 #define SUM_SELECTION_LIST   0x060000
 
@@ -258,6 +261,20 @@ static void cpy_opal_ruby_feat(struct sed_opalv200_supported_feat *header_to,
 	memcpy(header_to, header_from, sizeof(*header_to));
 }
 
+static void cpy_pyrite_feat(struct sed_pyrite_supported_feat *pyrite_feat,
+				void *feat)
+{
+	memcpy(pyrite_feat, (struct pyrite_supported_feat *) feat,
+			    sizeof(*pyrite_feat));
+}
+
+static void cpy_data_rm_mechanism_feat(struct sed_data_rm_mechanism_feat *data_rm_feat,
+				void *feat)
+{
+	memcpy(data_rm_feat, (struct data_rm_mechanism_feat *) feat,
+			     sizeof(*data_rm_feat));
+}
+
 static void cpy_cnl_feat(struct sed_opal_level0_discovery *discv, void *feat)
 {
 	memcpy(&discv->sed_cnl, (struct cnl_feat *) feat,
@@ -386,6 +403,38 @@ static int opal_level0_disc_pt(struct sed_device *device)
 			curr_feat->feat.ruby.base_comid = be16toh(
 					desc->feat.ruby.base_comid);
 			disc_data->comid = curr_feat->feat.ruby.base_comid;
+
+			feat_no++;
+			break;
+		case OPAL_FEAT_PYRITEV100:
+			curr_feat = &disc_data->feats[feat_no];
+			curr_feat->type = feat_code;
+			cpy_pyrite_feat(&discv->sed_pyritev100, &desc->feat.pyritev100);
+			discv->feat_avail_flag.feat_pyritev100 = 1;
+
+			curr_feat->feat.pyritev100.base_comid =
+				be16toh(desc->feat.pyritev100.base_comid);
+			disc_data->comid = curr_feat->feat.pyritev100.base_comid;
+
+			feat_no++;
+			break;
+		case OPAL_FEAT_PYRITEV200:
+			curr_feat = &disc_data->feats[feat_no];
+			curr_feat->type = feat_code;
+			cpy_pyrite_feat(&discv->sed_pyritev200, &desc->feat.pyritev200);
+			discv->feat_avail_flag.feat_pyritev200 = 1;
+
+			curr_feat->feat.pyritev200.base_comid =
+				be16toh(desc->feat.pyritev200.base_comid);
+			disc_data->comid = curr_feat->feat.pyritev200.base_comid;
+
+			feat_no++;
+			break;
+		case OPAL_FEAT_DATA_RM:
+			curr_feat = &disc_data->feats[feat_no];
+			curr_feat->type = feat_code;
+			cpy_data_rm_mechanism_feat(&discv->sed_data_rm_mechanism, &desc->feat.data_rm_mechanism);
+			discv->feat_avail_flag.feat_data_rm_mechanism = 1;
 
 			feat_no++;
 			break;

--- a/src/lib/nvme_pt_ioctl.h
+++ b/src/lib/nvme_pt_ioctl.h
@@ -255,6 +255,30 @@ struct opalv200_supported_feat {
 	uint8_t reserved2[5];
 } __attribute__((__packed__));
 
+struct pyrite_supported_feat {
+	uint16_t base_comid;
+	uint16_t comid_num;
+	uint8_t reserved[5];
+	uint8_t init_pin;
+	uint8_t revert_pin;
+	uint8_t reserved2[5];
+} __attribute__((__packed__));
+
+struct data_rm_mechanism_feat {
+	uint8_t reserved;
+	struct {
+		uint8_t rm_op_processing:1;
+		uint8_t rsvd1:7;
+	} __attribute__((__packed__)) rmopprocessing_rsvd;
+	uint8_t supp_data_rm_mechanism;
+	struct {
+		uint8_t data_rm_time_fmt:6;
+		uint8_t rsvd2:2;
+	} __attribute__((__packed__)) datarmtimefmtbits_rsvd;
+	uint16_t data_rm_time[6];
+	uint8_t reserved2[16];
+} __attribute__((__packed__));
+
 struct cnl_feat {
 	struct {
 		uint8_t rsvd1:6;
@@ -287,6 +311,10 @@ struct opal_l0_feat {
 		struct opalv200_supported_feat opalv200;
 
 		struct opalv200_supported_feat ruby;
+
+		struct pyrite_supported_feat pyritev100;
+
+		struct pyrite_supported_feat pyritev200;
 	} feat;
 };
 
@@ -332,6 +360,12 @@ struct opal_level0_feat_desc {
 		struct opalv200_supported_feat opalv200;
 
 		struct opalv200_supported_feat ruby;
+
+		struct pyrite_supported_feat pyritev100;
+
+		struct pyrite_supported_feat pyritev200;
+
+		struct data_rm_mechanism_feat data_rm_mechanism;
 
 		struct blocksid_supported_feat blocksid;
 


### PR DESCRIPTION
This patch introduces processing and displaying Level0 Discovery headers
for Pyrite v1.00 and v2.00.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@linux.intel.com>