### PR TITLE
libsed: fix opal parser deinitialization routine

### DIFF
--- a/src/lib/opal_parser.c
+++ b/src/lib/opal_parser.c
@@ -61,6 +61,7 @@ void opal_parser_deinit(void)
 		free(token_storage);
 		token_storage = NULL;
 	}
+	free_token_list.next = NULL;
 }
 
 static int append_short_atom_bytes_header(uint8_t *buf, size_t len, int data_len)


### PR DESCRIPTION
As pointed by after5cst opal_parser_deinit() wasn't reseting
free_token_list pointer. As a consequence flow involving sed_init +
sed_deinit + sed_init caused segmantetaion fault.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@linux.intel.com>