### PR TITLE
Allow setting MBR done while keeping setting or MBR shadow

### DIFF
--- a/src/sedcli_main.c
+++ b/src/sedcli_main.c
@@ -1033,7 +1033,7 @@ static int handle_mbr_control(void)
 	struct sed_device *dev = NULL;
 	int ret;
 
-	if (!opts->enable && opts->done) {
+	if (mbr_enable && !opts->enable && opts->done) {
 		sedcli_printf(LOG_ERR, "Error: disabling MBR shadow and setting "
 				"MBR done doesn't take any effect\n");
 


### PR DESCRIPTION
`sedcli -M -d /dev/sda -m TRUE` always gives `Error: disabling MBR shadow and setting MBR done doesn't take any effect`, this is not expected