### PR TITLE
libsed: Make opal_token become thread-safe

### DIFF
--- a/src/lib/opal_parser.c
+++ b/src/lib/opal_parser.c
@@ -26,8 +26,8 @@ struct _opal_token {
 };
 
 /* Token data storage  */
-static struct _opal_token free_token_list = { .next = NULL };
-static struct _opal_token *token_storage = NULL;
+static __thread struct _opal_token free_token_list = { .next = NULL };
+static __thread struct _opal_token *token_storage = NULL;
 
 static int div_roundup(int n, int d)
 {


### PR DESCRIPTION
Fix race condition when multiple threads use libsed simultaneously.

When multiple threads use libsed simultaneously. Global variable `token_storage` will be shared with multi-threads. This will cause memory leak and race condition.

[Reproduce step]
1. Write a small program with pthread.
2. Create 2 threads to do `sed_dev_discovery` simultaneously
(two threads discover two different NVMe devices respectively).
3. Both thread successfully discover, but only one thread can parse the result.